### PR TITLE
Fix CI error caused by setuptools-git-versioning 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.black]
 line-length = 100
 target-version = ['py38']  # as soon as black > 20.8b1 is released and we start using it, we can include py39 here
+
+# Leave this empty to avoid a bug introduced in setuptools-git-versioning 1.8.0
+# See https://github.com/dolfinus/setuptools-git-versioning/blob/df461e6b33493642ef39b96f8c5d68689f304bf7/setuptools_git_versioning.py#L180
+[tool.setuptools-git-versioning]


### PR DESCRIPTION
This version causes the simple existence of a pyproject.toml file to conflict with the configuration made in setup.py.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
