### PR TITLE
Revert "Uses shallow clones as default for Git operations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,8 +594,6 @@ with the `mod_auth_gssapi` module.
 
 * `include-git-dir` - when used, `.git` file objects are not removed from the source bundle created
   by Cachito. This is useful when the git history is important to the build process.
-  If this flag is absent, Cachito will use a shallow clone (depth=1) of the repository in order to save
-  resources.
 
 * `cgo-disable` - use this flag to make Cachito set `CGO_ENABLED=0` while processing gomod packages.
   This environment variable will only be used internally by Cachito, it will *not* be set in the

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -346,11 +346,7 @@ def create_request():
     error_callback = tasks.failed_request_callback.s(request.id)
     chain_tasks = [
         tasks.fetch_app_source.s(
-            request.repo,
-            request.ref,
-            request.id,
-            "git-submodule" in pkg_manager_names,
-            "include-git-dir" in [flag.name for flag in request.flags],
+            request.repo, request.ref, request.id, "git-submodule" in pkg_manager_names
         ).on_error(error_callback)
     ]
 

--- a/cachito/workers/tasks/general.py
+++ b/cachito/workers/tasks/general.py
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 
 @app.task(priority=0)
 @runs_if_request_in_progress
-def fetch_app_source(url, ref, request_id, gitsubmodule=False, include_git_dir=False):
+def fetch_app_source(url, ref, request_id, gitsubmodule=False):
     """
     Fetch the application source code that was requested and put it in long-term storage.
 
@@ -51,9 +51,7 @@ def fetch_app_source(url, ref, request_id, gitsubmodule=False, include_git_dir=F
     try:
         # Default to Git for now
         scm = Git(url, ref)
-        # In case don't need to keep the Git history, use a shallow clone to save resources
-        shallow = not include_git_dir
-        scm.fetch_source(gitsubmodule=gitsubmodule, shallow=shallow)
+        scm.fetch_source(gitsubmodule=gitsubmodule)
     except requests.Timeout:
         raise CachitoError("The connection timed out while downloading the source")
     except CachitoError:

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -110,7 +110,6 @@ def test_get_status_short(mock_status, error, client):
         ([], ["npm"], None, ["npm"], None,),
         ([], ["pip"], None, ["pip"], None,),
         ([], ["yarn"], None, ["yarn"], None,),
-        ([], [], None, [], ["include-git-dir"],),
     ),
 )
 @mock.patch("cachito.web.api_v1.chain")
@@ -163,7 +162,6 @@ def test_create_and_fetch_request(
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
             "git-submodule" in expected_pkg_managers,
-            "include-git-dir" in flags if flags is not None else False,
         ).on_error(error_callback)
     ]
     if "gomod" in expected_pkg_managers:
@@ -222,7 +220,6 @@ def test_create_request_with_gomod_package_configs(
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
             False,
-            False,
         ).on_error(error_callback),
         fetch_gomod_source.si(1, [], package_value["gomod"]).on_error(error_callback),
         process_fetched_sources.si(1).on_error(error_callback),
@@ -252,7 +249,6 @@ def test_create_request_with_npm_package_configs(
             "https://github.com/release-engineering/web-terminal.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
-            False,
             False,
         ).on_error(error_callback),
         fetch_npm_source.si(1, package_value["npm"]).on_error(error_callback),
@@ -294,7 +290,6 @@ def test_create_request_with_pip_package_configs(mock_chain, app, auth_env, clie
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
             False,
-            False,
         ).on_error(error_callback),
         fetch_pip_source.si(1, package_value["pip"]).on_error(error_callback),
         process_fetched_sources.si(1).on_error(error_callback),
@@ -324,7 +319,6 @@ def test_create_request_with_yarn_package_configs(
             "https://github.com/release-engineering/web-terminal.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
-            False,
             False,
         ).on_error(error_callback),
         fetch_yarn_source.si(1, package_value["yarn"]).on_error(error_callback),
@@ -377,7 +371,6 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
                 "https://github.com/release-engineering/retrodep.git",
                 "c50b93a32df1c9d700e3e80996845bc2e13be848",
                 1,
-                False,
                 False,
             ).on_error(error_callback),
             fetch_gomod_source.si(1, [], []).on_error(error_callback),


### PR DESCRIPTION
We are temporarily reverting this commit since we found that it causes Cachito to incorrectly infer Go versions in some corner cases. We're still figuring out a fix for this.

CLOUDBLD-8544

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
