### PR TITLE
Revert "Update py-amqp to latest version 5.0.9"

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,9 +10,9 @@ alembic==1.5.6 \
     # via
     #   -r requirements-web.txt
     #   flask-migrate
-amqp==5.0.9 \
-    --hash=sha256:1e5f707424e544078ca196e72ae6a14887ce74e02bd126be54b7c03c971bef18 \
-    --hash=sha256:9cd81f7b023fc04bbb108718fbac674f06901b77bfcdce85b10e2a5d0ee91be5
+amqp==5.0.2 \
+    --hash=sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a \
+    --hash=sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784
     # via
     #   -r requirements.txt
     #   kombu

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,7 @@
-amqp
+# FIXME: there was a regression in py-amqp. It was supposed to be fixed in
+# https://github.com/celery/py-amqp/pull/350
+# but cachito is still being affected by the regression
+amqp==5.0.2
 backoff
 celery>=5.2.2
 defusedxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 #
-amqp==5.0.9 \
-    --hash=sha256:1e5f707424e544078ca196e72ae6a14887ce74e02bd126be54b7c03c971bef18 \
-    --hash=sha256:9cd81f7b023fc04bbb108718fbac674f06901b77bfcdce85b10e2a5d0ee91be5
+amqp==5.0.2 \
+    --hash=sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a \
+    --hash=sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784
     # via
     #   -r requirements.in
     #   kombu


### PR DESCRIPTION
CLOUDBLD-4312

The issue that happens in python3-amqp>=5.0.2 is still present, and causes Cachito to not be able to properly resolve the certificates. The issue was identified while the service was deployed to Openshift, and the error probably does not happen in a local environment.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
