### PR TITLE
Set SSL_CERT_FILE, for custom CAs and intermediate certificates

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -28,6 +28,8 @@ RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+# Use the system CA bundle for native SSL calls from celery (python)
+ENV SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
 
 # Disable gitpython check for the git executable, cachito-api doesn't use git
 ENV GIT_PYTHON_REFRESH=quiet

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -31,6 +31,8 @@ RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+# Use the system CA bundle for native SSL calls from celery (python)
+ENV SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
 
 # Set git user configuration for GitPython
 ENV GIT_COMMITTER_NAME=cachito \


### PR DESCRIPTION
Signed-off-by: Mike Kingsbury <mike.kingsbury@redhat.com>

# Maintainers will complete the following section

- [ X ] Commit messages are descriptive enough
- [ N/A ] Code coverage from testing does not decrease and new code is covered
- [ N/A ] OpenAPI schema is updated (if applicable)
- [ N/A ] DB schema change has corresponding DB migration (if applicable)
- [ N/A ] README updated (if worker configuration changed, or if applicable)
