### PR TITLE
Ignore npmv7 workspace item from dependencies list

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -25,7 +25,7 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-def _get_deps(package_lock_deps, file_deps_allowlist, _name_to_deps=None, workspaces=None):
+def _get_deps(package_lock_deps, file_deps_allowlist, name_to_deps=None, workspaces=None):
     """
     Get a mapping of dependencies to all versions of the dependency.
 
@@ -46,7 +46,7 @@ def _get_deps(package_lock_deps, file_deps_allowlist, _name_to_deps=None, worksp
     :param dict package_lock_deps: the value of a "dependencies" key in a package-lock.json file
     :param set file_deps_allowlist: an allow list of dependencies that are allowed to be "file"
         dependencies and should be ignored since they are implementation details
-    :param dict _name_to_deps: the current mapping of dependencies; this is not meant to be set
+    :param dict name_to_deps: the current mapping of dependencies; this is not meant to be set
         by the caller
     :param list workspaces: package workspaces defined in package-lock.json
     :return: a tuple with the first item as the mapping of dependencies where each key is a
@@ -56,8 +56,8 @@ def _get_deps(package_lock_deps, file_deps_allowlist, _name_to_deps=None, worksp
     :rtype: (dict, list)
     :raise CachitoError: if the lock file contains a dependency from an unsupported location
     """
-    if _name_to_deps is None:
-        _name_to_deps = {}
+    if name_to_deps is None:
+        name_to_deps = {}
     elif workspaces is None:
         workspaces = []
 
@@ -99,8 +99,8 @@ def _get_deps(package_lock_deps, file_deps_allowlist, _name_to_deps=None, worksp
             info.clear()
             info.update(nexus_replacement)
 
-        _name_to_deps.setdefault(name, [])
-        for d in _name_to_deps[name]:
+        name_to_deps.setdefault(name, [])
+        for d in name_to_deps[name]:
             if d["version"] == dep["version"]:
                 # If a duplicate version was found but this one isn't bundled, then mark the
                 # dependency as not bundled so it's included individually in the deps directory
@@ -112,18 +112,18 @@ def _get_deps(package_lock_deps, file_deps_allowlist, _name_to_deps=None, worksp
                     d["dev"] = False
                 break
         else:
-            _name_to_deps[name].append(dep)
+            name_to_deps[name].append(dep)
 
         if "dependencies" in info:
             _, returned_nexus_replacements = _get_deps(
-                info["dependencies"], file_deps_allowlist, _name_to_deps
+                info["dependencies"], file_deps_allowlist, name_to_deps
             )
             # If any of the dependencies were non-registry dependencies, replace the requires to be
             # the version in Nexus
             for name, version in returned_nexus_replacements:
                 info["requires"][name] = version
 
-    return _name_to_deps, nexus_replacements
+    return name_to_deps, nexus_replacements
 
 
 def convert_to_nexus_hosted(dep_name, dep_info):

--- a/tests/integration/test_data/npm_packages.yaml
+++ b/tests/integration/test_data/npm_packages.yaml
@@ -358,3 +358,39 @@ git_submodule:
     - "pkg:npm/get-func-name@2.0.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
+# npm package for testing workspaces
+# repo: The URL for the upstream git repository
+# ref: A git reference at the given git repository
+# expected_files: Expected source files <relative_path>: <file_URL>
+# response_expectations: Parts of the Cachito response to check
+# content_manifest: PURLs for image contents part
+workspaces:
+  repo: https://github.com/cachito-testing/cachito-npm-workspaces.git
+  ref: 7a83936be7177246a549acf66ab8074ea4c0d6f5 
+  pkg_managers: ["npm"]
+  expected_files:
+    app: https://github.com/cachito-testing/cachito-npm-workspaces/tarball/7a83936be7177246a549acf66ab8074ea4c0d6f5
+    deps/npm/abbrev/abbrev-1.1.1.tgz: https://registry.npmjs.com/abbrev/-/abbrev-1.1.1.tgz
+  response_expectations:
+    dependencies:
+      - dev: false
+        name: abbrev
+        replaces: null
+        type: npm
+        version: 1.1.1
+    packages:
+      - dependencies:
+        - dev: false
+          name: abbrev
+          replaces: null
+          type: npm
+          version: 1.1.1
+        name: "npm_test"
+        type: "npm"
+        version: "1.0.0"
+  content_manifest:
+  - purl: "pkg:github/cachito-testing/cachito-npm-workspaces@7a83936be7177246a549acf66ab8074ea4c0d6f5"
+    dep_purls:
+      - "pkg:npm/abbrev@1.1.1"
+    source_purls:
+      - "pkg:npm/abbrev@1.1.1"

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -33,6 +33,7 @@ from . import utils
         ("npm_packages", "without_deps"),
         ("npm_packages", "with_deps"),
         ("npm_packages", "git_submodule"),
+        ("npm_packages", "workspaces"),
         ("yarn_packages", "without_deps"),
         ("yarn_packages", "with_deps"),
         ("yarn_packages", "git_submodule"),

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -463,7 +463,7 @@ def test_get_deps_unsupported_non_registry_dep():
     }
     expected = "The dependency tslib@file:tslib.tar.gz is hosted in an unsupported location"
     with pytest.raises(CachitoError, match=expected):
-        npm._get_deps(package_lock_deps, set(), {})
+        npm._get_deps(package_lock_deps, set(), name_to_deps={})
 
 
 def test_get_npm_proxy_repo_name():


### PR DESCRIPTION
Workspace is a new feature introduced by npm v7. When the workspace
is enabled, there will be an item recorded under dependencies object
within package-lock.json, and the item has version value
with prefix "file:". Such item can be skipped in order to not confuse
Cachito to treat it as a normal dependency.

CLOUDBLD-6981

Signed-off-by: ejegrova <ejegrova@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
