### PR TITLE
Add ignore_dev_deps as a new package argument

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -184,10 +184,10 @@ def _validate_request_package_configs(request_kwargs, pkg_managers_names):
 
     # Validate the values for each package manager configuration (e.g. packages.npm)
     valid_package_config_keys = {
-        "npm": {"path"},
+        "npm": {"path", "ignore_dev_deps"},
         "pip": {"path", "requirements_build_files", "requirements_files"},
         "gomod": {"path"},
-        "yarn": {"path"},
+        "yarn": {"path", "ignore_dev_deps"},
     }
     for pkg_manager, packages_config in packages_configs.items():
         invalid_format_error = (
@@ -207,6 +207,8 @@ def _validate_request_package_configs(request_kwargs, pkg_managers_names):
 
             if package_config.get("path") is not None:
                 _validate_configuration_path_value(pkg_manager, "path", package_config["path"])
+            for path in package_config.get("ignore_dev_deps", []):
+                _validate_configuration_path_value(pkg_manager, "ignore_dev_deps", path)
             for path in package_config.get("requirements_files", []):
                 _validate_configuration_path_value(pkg_manager, "requirements_files", path)
             for path in package_config.get("requirements_build_files", []):

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -44,6 +44,7 @@ def download_dependencies(
     proxy_repo_url: str,
     skip_deps: Optional[Set[str]] = None,
     pkg_manager: str = "npm",
+    ignore_dev_deps: bool = False,
 ) -> Set[str]:
     """
     Download the list of npm dependencies using npm pack to the deps bundle directory.
@@ -66,6 +67,7 @@ def download_dependencies(
         already been downloaded for this request.
     :param str pkg_manager: the name of the package manager to download dependencies for, affects
         destination directory and logging output (npm is used to do the actual download regardless)
+    :param bool ignore_dev_deps: flag to indicate that Dev dependencies should not be downloaded
     :return: a set of dependency identifiers that were downloaded
     :rtype: set[str]
     :raises CachitoError: if any of the downloads fail
@@ -131,6 +133,9 @@ def download_dependencies(
                 log.debug(
                     "Not downloading %s since it was already downloaded previously", dep_identifier
                 )
+                continue
+            elif ignore_dev_deps and dep["dev"]:
+                log.debug("Not downloading %s since it is a Dev dependency, and ignore_dev_deps flag is true", dep_identifier)
                 continue
 
             if counter % batch_size == 0:

--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -316,7 +316,11 @@ def resolve_npm(app_source_path, request, skip_deps=None):
     bundle_dir = RequestBundleDir(request["id"])
     bundle_dir.npm_deps_dir.mkdir(exist_ok=True)
     package_and_deps_info["downloaded_deps"] = download_dependencies(
-        bundle_dir.npm_deps_dir, package_and_deps_info["deps"], proxy_repo_url, skip_deps,
+        bundle_dir.npm_deps_dir,
+        package_and_deps_info["deps"],
+        proxy_repo_url,
+        skip_deps,
+        # ignore_dev_deps=SET FLAG TO INPUT VALUE,
     )
 
     # Remove all the "bundled" keys since that is an implementation detail that should not be

--- a/cachito/workers/pkg_managers/yarn.py
+++ b/cachito/workers/pkg_managers/yarn.py
@@ -478,6 +478,7 @@ def resolve_yarn(app_source_path, request, skip_deps=None):
         proxy_repo_url,
         skip_deps=skip_deps,
         pkg_manager="yarn",
+        # ignore_dev_deps=SET FLAG TO INPUT VALUE,
     )
 
     replacements = package_and_deps_info.pop("nexus_replacements")


### PR DESCRIPTION
CLOUDBLD-2816

The flag ignore_dev_deps, when set to true, prevents Cachito from
downloading Dev dependencies.

Signed-off-by: Daniel Cho <dacho@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
