### PR TITLE
Update integration test yaml files to reflect new dependencies

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -592,11 +592,6 @@ npm_cached_deps:
         type: npm
         version: 1.1.0
       - dev: false
-        name: cachito-npm-without-deps
-        replaces: null
-        type: npm
-        version: github:cachito-testing/cachito-npm-without-deps#2f0ce1d7b1f8b35572d919428b965285a69583f6
-      - dev: false
         name: chai
         replaces: null
         type: npm
@@ -622,25 +617,25 @@ npm_cached_deps:
         type: npm
         version: 2.0.0
       - dev: false
+        name: is-positive
+        replaces: null
+        type: npm
+        version: github:kevva/is-positive#97edff6f525f192a3f83cea1944765f769ae2678
+      - dev: false
         name: pathval
         replaces: null
         type: npm
         version: 1.1.1
-      - dev: false
-        name: test-npm-dep
-        replaces: null
-        type: npm
-        version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
       - dev: false
         name: type-detect
         replaces: null
         type: npm
         version: 4.0.8
       - dev: true
-        name: npm-test-project
+        name: cachito-npm-without-deps
         replaces: null
         type: npm
-        version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+        version: git+https://github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
     packages:
       - dependencies:
         - dev: false
@@ -648,11 +643,6 @@ npm_cached_deps:
           replaces: null
           type: npm
           version: 1.1.0
-        - dev: false
-          name: cachito-npm-without-deps
-          replaces: null
-          type: npm
-          version: github:cachito-testing/cachito-npm-without-deps#2f0ce1d7b1f8b35572d919428b965285a69583f6
         - dev: false
           name: chai
           replaces: null
@@ -679,25 +669,25 @@ npm_cached_deps:
           type: npm
           version: 2.0.0
         - dev: false
+          name: is-positive
+          replaces: null
+          type: npm
+          version: github:kevva/is-positive#97edff6f525f192a3f83cea1944765f769ae2678
+        - dev: false
           name: pathval
           replaces: null
           type: npm
           version: 1.1.1
-        - dev: false
-          name: test-npm-dep
-          replaces: null
-          type: npm
-          version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
         - dev: false
           name: type-detect
           replaces: null
           type: npm
           version: 4.0.8
         - dev: true
-          name: npm-test-project
+          name: cachito-npm-without-deps
           replaces: null
           type: npm
-          version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+          version: git+https://github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
         name: cachito-npm-with-deps
         type: npm
         version: 1.0.0
@@ -709,10 +699,9 @@ npm_cached_deps:
     deps/npm/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
     deps/npm/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
     deps/npm/external-fecha/fecha-4.2.0-external-sha512-8ae71e98d68e38e1f6e4c629187684dd85e4dc96647c7219b1dd189598ea52865e947f0ad94a7001fa8fb5eccf58467fe34ad10066e831af3374120134604bd5.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-npm.tgz
-    deps/npm/external-npm-test-project/npm-test-project-1.0.0-external-gitcommit-88114c48d7d894f7e2306adf06137b096e9cdf29.tgz: https://github.com/cachito-testing/test_files/raw/master/npm-test-project-1.0.0.tgz
-    deps/npm/external-test-npm-dep/test-npm-dep-1.0.0-external-gitcommit-b952715c0706f30d92a7253dcdadc510a618eca5.tgz: https://github.com/cachito-testing/test_files/raw/master/test-npm-dep-1.0.0.tgz
+    deps/npm/external-cachito-npm-without-deps/cachito-npm-without-deps-1.0.0-external-gitcommit-2f0ce1d7b1f8b35572d919428b965285a69583f6.tgz: https://github.com/cachito-testing/test_files/raw/master/cachito-npm-without-deps-1.0.0.tgz
     deps/npm/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
-    deps/npm/github/cachito-testing/cachito-npm-without-deps/cachito-npm-without-deps-1.0.0-external-gitcommit-2f0ce1d7b1f8b35572d919428b965285a69583f6.tgz: https://github.com/cachito-testing/test_files/raw/master/cachito-npm-without-deps-1.0.0.tgz
+    deps/npm/github/kevva/is-positive/is-positive-3.1.0-external-gitcommit-97edff6f525f192a3f83cea1944765f769ae2678.tgz: https://github.com/cachito-testing/test_files/raw/master/kevva_is-positive.tar.xz
     deps/npm/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/npm/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   # Expected content manifest data
@@ -720,8 +709,7 @@ npm_cached_deps:
     purl: "pkg:github/cachito-testing/cachito-npm-with-deps@MAIN_REPO_COMMIT"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
-    - "pkg:github/cachito-testing/cachito-npm-without-deps@2f0ce1d7b1f8b35572d919428b965285a69583f6"
+    - "pkg:github/kevva/is-positive@97edff6f525f192a3f83cea1944765f769ae2678"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
@@ -730,10 +718,9 @@ npm_cached_deps:
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
+    - "pkg:generic/cachito-npm-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-npm-without-deps.git%232f0ce1d7b1f8b35572d919428b965285a69583f6"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
-    - "pkg:github/cachito-testing/cachito-npm-without-deps@2f0ce1d7b1f8b35572d919428b965285a69583f6"
+    - "pkg:github/kevva/is-positive@97edff6f525f192a3f83cea1944765f769ae2678"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
@@ -767,6 +754,11 @@ yarn_cached_deps:
         type: yarn
         version: 1.1.0
       - dev: false
+        name: cachito-yarn-without-deps
+        replaces: null
+        type: yarn
+        version: git+https://github.com/cachito-testing/cachito-yarn-without-deps.git#da0a2888aa7aab37fec34c0b36d9e44560d2cf3e
+      - dev: false
         name: chai
         replaces: null
         type: yarn
@@ -792,20 +784,15 @@ yarn_cached_deps:
         type: yarn
         version: 2.0.0
       - dev: false
-        name: npm-test-project
+        name: is-positive
         replaces: null
         type: yarn
-        version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+        version: 3.1.0
       - dev: false
         name: pathval
         replaces: null
         type: yarn
         version: 1.1.1
-      - dev: false
-        name: test-npm-dep
-        replaces: null
-        type: yarn
-        version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
       - dev: false
         name: type-detect
         replaces: null
@@ -818,6 +805,11 @@ yarn_cached_deps:
           replaces: null
           type: yarn
           version: 1.1.0
+        - dev: false
+          name: cachito-yarn-without-deps
+          replaces: null
+          type: yarn
+          version: git+https://github.com/cachito-testing/cachito-yarn-without-deps.git#da0a2888aa7aab37fec34c0b36d9e44560d2cf3e
         - dev: false
           name: chai
           replaces: null
@@ -844,20 +836,15 @@ yarn_cached_deps:
           type: yarn
           version: 2.0.0
         - dev: false
-          name: npm-test-project
+          name: is-positive
           replaces: null
           type: yarn
-          version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+          version: 3.1.0
         - dev: false
           name: pathval
           replaces: null
           type: yarn
           version: 1.1.1
-        - dev: false
-          name: test-npm-dep
-          replaces: null
-          type: yarn
-          version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
         - dev: false
           name: type-detect
           replaces: null
@@ -873,32 +860,30 @@ yarn_cached_deps:
     deps/yarn/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
     deps/yarn/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
     deps/yarn/external-fecha/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-91680e4db1415fea33eac878cfd889c80a7b55c7.tgz
-    deps/yarn/external-npm-test-project/npm-test-project-1.0.0-external-gitcommit-88114c48d7d894f7e2306adf06137b096e9cdf29.tgz: https://github.com/cachito-testing/test_files/raw/master/npm-test-project-1.0.0.tgz
-    deps/yarn/external-test-npm-dep/test-npm-dep-1.0.0-external-gitcommit-b952715c0706f30d92a7253dcdadc510a618eca5.tgz: https://github.com/cachito-testing/test_files/raw/master/test-npm-dep-1.0.0.tgz
     deps/yarn/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
     deps/yarn/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/yarn/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
     purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@MAIN_REPO_COMMIT"
     dep_purls:
+    - "pkg:generic/cachito-yarn-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-yarn-without-deps.git%23da0a2888aa7aab37fec34c0b36d9e44560d2cf3e"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
+    - "pkg:npm/is-positive@3.1.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
+    - "pkg:generic/cachito-yarn-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-yarn-without-deps.git%23da0a2888aa7aab37fec34c0b36d9e44560d2cf3e"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
+    - "pkg:npm/is-positive@3.1.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"

--- a/tests/integration/test_data/npm_packages.yaml
+++ b/tests/integration/test_data/npm_packages.yaml
@@ -32,7 +32,7 @@ without_deps:
 # content_manifest: PURLs for image contents part
 with_deps:
   repo: https://github.com/cachito-testing/cachito-npm-with-deps.git
-  ref: 86af61f8a1f4e4afdd69a90782b917dd7088f84a
+  ref: 565aba4c7f210c6196c1b522e2279f853f77d6d2
   pkg_managers: ["npm"]
   response_expectations:
     dependencies:
@@ -41,11 +41,6 @@ with_deps:
         replaces: null
         type: npm
         version: 1.1.0
-      - dev: false
-        name: cachito-npm-without-deps
-        replaces: null
-        type: npm
-        version: github:cachito-testing/cachito-npm-without-deps#2f0ce1d7b1f8b35572d919428b965285a69583f6
       - dev: false
         name: chai
         replaces: null
@@ -72,25 +67,25 @@ with_deps:
         type: npm
         version: 2.0.0
       - dev: false
+        name: is-positive
+        replaces: null
+        type: npm
+        version: github:kevva/is-positive#97edff6f525f192a3f83cea1944765f769ae2678
+      - dev: false
         name: pathval
         replaces: null
         type: npm
         version: 1.1.1
-      - dev: false
-        name: test-npm-dep
-        replaces: null
-        type: npm
-        version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
       - dev: false
         name: type-detect
         replaces: null
         type: npm
         version: 4.0.8
       - dev: true
-        name: npm-test-project
+        name: cachito-npm-without-deps
         replaces: null
         type: npm
-        version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+        version: git+https://github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
     packages:
       - dependencies:
         - dev: false
@@ -152,7 +147,7 @@ with_deps:
         type: npm
         version: 1.0.0
   expected_files:
-    app: https://github.com/cachito-testing/cachito-npm-with-deps/tarball/86af61f8a1f4e4afdd69a90782b917dd7088f84a
+    app: https://github.com/cachito-testing/cachito-npm-with-deps/tarball/565aba4c7f210c6196c1b522e2279f853f77d6d2
     deps/npm/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
     deps/npm/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
     deps/npm/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
@@ -165,7 +160,7 @@ with_deps:
     deps/npm/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/npm/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
-  - purl: "pkg:github/cachito-testing/cachito-npm-with-deps@86af61f8a1f4e4afdd69a90782b917dd7088f84a"
+  - purl: "pkg:github/cachito-testing/cachito-npm-with-deps@565aba4c7f210c6196c1b522e2279f853f77d6d2"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
     - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
@@ -197,7 +192,7 @@ git_submodule:
   packages:
     npm: [{"path": "cachito-npm-with-deps"}]
   expected_files:
-    app: https://github.com/cachito-testing/git-submodule-npm-tarball/tarball/7c1386b804c7acaa6bd20155d14a11addb2a0346
+    app: https://github.com/cachito-testing/git-submodule-npm-tarball/tarball/cd559dbe8655faa85d55b93aa81fd6e9c9b4d6af
     deps/npm/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
     deps/npm/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
     deps/npm/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
@@ -271,7 +266,7 @@ git_submodule:
         name: cachito-npm-with-deps
         path: cachito-npm-with-deps
         type: git-submodule
-        version: https://github.com/cachito-testing/cachito-npm-with-deps.git#86af61f8a1f4e4afdd69a90782b917dd7088f84a
+        version: https://github.com/cachito-testing/cachito-npm-with-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
       - dependencies:
         - dev: false
           name: assertion-error
@@ -333,7 +328,7 @@ git_submodule:
         type: npm
         version: 1.0.0
   content_manifest:
-  - purl: "pkg:github/cachito-testing/cachito-npm-with-deps@86af61f8a1f4e4afdd69a90782b917dd7088f84a"
+  - purl: "pkg:github/cachito-testing/cachito-npm-with-deps@565aba4c7f210c6196c1b522e2279f853f77d6d2"
   - purl: "pkg:github/cachito-testing/git-submodule-npm@ab5482a3257f1d91d0e580fcdd51ba5fb325115b#cachito-npm-with-deps"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"

--- a/tests/integration/test_data/npm_packages.yaml
+++ b/tests/integration/test_data/npm_packages.yaml
@@ -94,11 +94,6 @@ with_deps:
           type: npm
           version: 1.1.0
         - dev: false
-          name: cachito-npm-without-deps
-          replaces: null
-          type: npm
-          version: github:cachito-testing/cachito-npm-without-deps#2f0ce1d7b1f8b35572d919428b965285a69583f6
-        - dev: false
           name: chai
           replaces: null
           type: npm
@@ -124,25 +119,25 @@ with_deps:
           type: npm
           version: 2.0.0
         - dev: false
+          name: is-positive
+          replaces: null
+          type: npm
+          version: github:kevva/is-positive#97edff6f525f192a3f83cea1944765f769ae2678
+        - dev: false
           name: pathval
           replaces: null
           type: npm
           version: 1.1.1
-        - dev: false
-          name: test-npm-dep
-          replaces: null
-          type: npm
-          version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
         - dev: false
           name: type-detect
           replaces: null
           type: npm
           version: 4.0.8
         - dev: true
-          name: npm-test-project
+          name: cachito-npm-without-deps
           replaces: null
           type: npm
-          version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+          version: git+https://github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
         name: cachito-npm-with-deps
         type: npm
         version: 1.0.0
@@ -153,18 +148,15 @@ with_deps:
     deps/npm/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
     deps/npm/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
     deps/npm/external-fecha/fecha-4.2.0-external-sha512-8ae71e98d68e38e1f6e4c629187684dd85e4dc96647c7219b1dd189598ea52865e947f0ad94a7001fa8fb5eccf58467fe34ad10066e831af3374120134604bd5.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-npm.tgz
-    deps/npm/external-npm-test-project/npm-test-project-1.0.0-external-gitcommit-88114c48d7d894f7e2306adf06137b096e9cdf29.tgz: https://github.com/cachito-testing/test_files/raw/master/npm-test-project-1.0.0.tgz
-    deps/npm/external-test-npm-dep/test-npm-dep-1.0.0-external-gitcommit-b952715c0706f30d92a7253dcdadc510a618eca5.tgz: https://github.com/cachito-testing/test_files/raw/master/test-npm-dep-1.0.0.tgz
     deps/npm/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
-    deps/npm/github/cachito-testing/cachito-npm-without-deps/cachito-npm-without-deps-1.0.0-external-gitcommit-2f0ce1d7b1f8b35572d919428b965285a69583f6.tgz:  https://github.com/cachito-testing/test_files/raw/master/cachito-npm-without-deps-1.0.0.tgz
+    deps/npm/github/kevva/is-positive/is-positive-3.1.0-external-gitcommit-97edff6f525f192a3f83cea1944765f769ae2678.tgz: https://github.com/cachito-testing/test_files/raw/master/kevva_is-positive.tar.xz
     deps/npm/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/npm/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-with-deps@565aba4c7f210c6196c1b522e2279f853f77d6d2"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
-    - "pkg:github/cachito-testing/cachito-npm-without-deps@2f0ce1d7b1f8b35572d919428b965285a69583f6"
+    - "pkg:github/kevva/is-positive@97edff6f525f192a3f83cea1944765f769ae2678"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
@@ -173,10 +165,9 @@ with_deps:
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
+    - "pkg:generic/cachito-npm-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-npm-without-deps.git%232f0ce1d7b1f8b35572d919428b965285a69583f6"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
-    - "pkg:github/cachito-testing/cachito-npm-without-deps@2f0ce1d7b1f8b35572d919428b965285a69583f6"
+    - "pkg:github/kevva/is-positive@97edff6f525f192a3f83cea1944765f769ae2678"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
@@ -187,23 +178,10 @@ with_deps:
 # With npm git-submodule
 git_submodule:
   repo: https://github.com/cachito-testing/git-submodule-npm.git
-  ref: ab5482a3257f1d91d0e580fcdd51ba5fb325115b
+  ref: a209a89d1b88b757cd7dfd19bb2d96dd979398d6
   pkg_managers: ["npm", "git-submodule"]
   packages:
     npm: [{"path": "cachito-npm-with-deps"}]
-  expected_files:
-    app: https://github.com/cachito-testing/git-submodule-npm-tarball/tarball/cd559dbe8655faa85d55b93aa81fd6e9c9b4d6af
-    deps/npm/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
-    deps/npm/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
-    deps/npm/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
-    deps/npm/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
-    deps/npm/external-fecha/fecha-4.2.0-external-sha512-8ae71e98d68e38e1f6e4c629187684dd85e4dc96647c7219b1dd189598ea52865e947f0ad94a7001fa8fb5eccf58467fe34ad10066e831af3374120134604bd5.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-npm.tgz
-    deps/npm/external-npm-test-project/npm-test-project-1.0.0-external-gitcommit-88114c48d7d894f7e2306adf06137b096e9cdf29.tgz: https://github.com/cachito-testing/test_files/raw/master/npm-test-project-1.0.0.tgz
-    deps/npm/external-test-npm-dep/test-npm-dep-1.0.0-external-gitcommit-b952715c0706f30d92a7253dcdadc510a618eca5.tgz: https://github.com/cachito-testing/test_files/raw/master/test-npm-dep-1.0.0.tgz
-    deps/npm/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
-    deps/npm/github/cachito-testing/cachito-npm-without-deps/cachito-npm-without-deps-1.0.0-external-gitcommit-2f0ce1d7b1f8b35572d919428b965285a69583f6.tgz:  https://github.com/cachito-testing/test_files/raw/master/cachito-npm-without-deps-1.0.0.tgz
-    deps/npm/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
-    deps/npm/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   response_expectations:
     dependencies:
       - dev: false
@@ -211,11 +189,6 @@ git_submodule:
         replaces: null
         type: npm
         version: 1.1.0
-      - dev: false
-        name: cachito-npm-without-deps
-        replaces: null
-        type: npm
-        version: github:cachito-testing/cachito-npm-without-deps#2f0ce1d7b1f8b35572d919428b965285a69583f6
       - dev: false
         name: chai
         replaces: null
@@ -242,42 +215,37 @@ git_submodule:
         type: npm
         version: 2.0.0
       - dev: false
+        name: is-positive
+        replaces: null
+        type: npm
+        version: github:kevva/is-positive#97edff6f525f192a3f83cea1944765f769ae2678
+      - dev: false
         name: pathval
         replaces: null
         type: npm
         version: 1.1.1
-      - dev: false
-        name: test-npm-dep
-        replaces: null
-        type: npm
-        version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
       - dev: false
         name: type-detect
         replaces: null
         type: npm
         version: 4.0.8
       - dev: true
-        name: npm-test-project
+        name: cachito-npm-without-deps
         replaces: null
         type: npm
-        version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+        version: git+https://github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
     packages:
       - dependencies: []
         name: cachito-npm-with-deps
         path: cachito-npm-with-deps
         type: git-submodule
-        version: https://github.com/cachito-testing/cachito-npm-with-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
+        version: https://github.com/cachito-testing/cachito-npm-with-deps.git#565aba4c7f210c6196c1b522e2279f853f77d6d2
       - dependencies:
         - dev: false
           name: assertion-error
           replaces: null
           type: npm
           version: 1.1.0
-        - dev: false
-          name: cachito-npm-without-deps
-          replaces: null
-          type: npm
-          version: github:cachito-testing/cachito-npm-without-deps#2f0ce1d7b1f8b35572d919428b965285a69583f6
         - dev: false
           name: chai
           replaces: null
@@ -304,36 +272,45 @@ git_submodule:
           type: npm
           version: 2.0.0
         - dev: false
+          name: is-positive
+          replaces: null
+          type: npm
+          version: github:kevva/is-positive#97edff6f525f192a3f83cea1944765f769ae2678
+        - dev: false
           name: pathval
           replaces: null
           type: npm
           version: 1.1.1
-        - dev: false
-          name: test-npm-dep
-          replaces: null
-          type: npm
-          version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
         - dev: false
           name: type-detect
           replaces: null
           type: npm
           version: 4.0.8
         - dev: true
-          name: npm-test-project
+          name: cachito-npm-without-deps
           replaces: null
           type: npm
-          version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+          version: git+https://github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
         name: cachito-npm-with-deps
         path: cachito-npm-with-deps
         type: npm
         version: 1.0.0
+  expected_files:
+    app: https://github.com/cachito-testing/git-submodule-npm-tarball/tarball/0b2b5b6ce7fca4226a4ed081b3b04b830f2fdb5e
+    deps/npm/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
+    deps/npm/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
+    deps/npm/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
+    deps/npm/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
+    deps/npm/external-fecha/fecha-4.2.0-external-sha512-8ae71e98d68e38e1f6e4c629187684dd85e4dc96647c7219b1dd189598ea52865e947f0ad94a7001fa8fb5eccf58467fe34ad10066e831af3374120134604bd5.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-npm.tgz
+    deps/npm/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
+    deps/npm/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
+    deps/npm/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-with-deps@565aba4c7f210c6196c1b522e2279f853f77d6d2"
-  - purl: "pkg:github/cachito-testing/git-submodule-npm@ab5482a3257f1d91d0e580fcdd51ba5fb325115b#cachito-npm-with-deps"
+  - purl: "pkg:github/cachito-testing/git-submodule-npm@a209a89d1b88b757cd7dfd19bb2d96dd979398d6#cachito-npm-with-deps"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
-    - "pkg:github/cachito-testing/cachito-npm-without-deps@2f0ce1d7b1f8b35572d919428b965285a69583f6"
+    - "pkg:github/kevva/is-positive@97edff6f525f192a3f83cea1944765f769ae2678"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
@@ -342,10 +319,9 @@ git_submodule:
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
+    - "pkg:generic/cachito-npm-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-npm-without-deps.git%232f0ce1d7b1f8b35572d919428b965285a69583f6"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
-    - "pkg:github/cachito-testing/cachito-npm-without-deps@2f0ce1d7b1f8b35572d919428b965285a69583f6"
+    - "pkg:github/kevva/is-positive@97edff6f525f192a3f83cea1944765f769ae2678"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"

--- a/tests/integration/test_data/yarn_packages.yaml
+++ b/tests/integration/test_data/yarn_packages.yaml
@@ -32,7 +32,7 @@ without_deps:
 # content_manifest: PURLs for image contents part
 with_deps:
   repo: https://github.com/cachito-testing/cachito-yarn-with-deps.git
-  ref: cfae8edfadcbcb384905f8bd11ef288ae41b560e
+  ref: e1cc10b76c580cdd6cbdfc83bf1692503385447e
   pkg_managers: ["yarn"]
   response_expectations:
     dependencies:
@@ -41,6 +41,11 @@ with_deps:
         replaces: null
         type: yarn
         version: 1.1.0
+      - dev: false
+        name: cachito-yarn-without-deps
+        replaces: null
+        type: yarn
+        version: git+https://github.com/cachito-testing/cachito-yarn-without-deps.git#da0a2888aa7aab37fec34c0b36d9e44560d2cf3e
       - dev: false
         name: chai
         replaces: null
@@ -67,20 +72,15 @@ with_deps:
         type: yarn
         version: 2.0.0
       - dev: false
-        name: npm-test-project
+        name: is-positive
         replaces: null
         type: yarn
-        version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+        version: 3.1.0
       - dev: false
         name: pathval
         replaces: null
         type: yarn
         version: 1.1.1
-      - dev: false
-        name: test-npm-dep
-        replaces: null
-        type: yarn
-        version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
       - dev: false
         name: type-detect
         replaces: null
@@ -93,6 +93,11 @@ with_deps:
           replaces: null
           type: yarn
           version: 1.1.0
+        - dev: false
+          name: cachito-yarn-without-deps
+          replaces: null
+          type: yarn
+          version: git+https://github.com/cachito-testing/cachito-yarn-without-deps.git#da0a2888aa7aab37fec34c0b36d9e44560d2cf3e
         - dev: false
           name: chai
           replaces: null
@@ -119,20 +124,15 @@ with_deps:
           type: yarn
           version: 2.0.0
         - dev: false
-          name: npm-test-project
+          name: is-positive
           replaces: null
           type: yarn
-          version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+          version: 3.1.0
         - dev: false
           name: pathval
           replaces: null
           type: yarn
           version: 1.1.1
-        - dev: false
-          name: test-npm-dep
-          replaces: null
-          type: yarn
-          version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
         - dev: false
           name: type-detect
           replaces: null
@@ -142,60 +142,46 @@ with_deps:
         type: yarn
         version: 1.0.0
   expected_files:
-    app: https://github.com/cachito-testing/cachito-yarn-with-deps/tarball/cfae8edfadcbcb384905f8bd11ef288ae41b560e
+    app: https://github.com/cachito-testing/cachito-yarn-with-deps/tarball/e1cc10b76c580cdd6cbdfc83bf1692503385447e
     deps/yarn/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
     deps/yarn/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
     deps/yarn/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
     deps/yarn/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
     deps/yarn/external-fecha/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-91680e4db1415fea33eac878cfd889c80a7b55c7.tgz
-    deps/yarn/external-npm-test-project/npm-test-project-1.0.0-external-gitcommit-88114c48d7d894f7e2306adf06137b096e9cdf29.tgz: https://github.com/cachito-testing/test_files/raw/master/npm-test-project-1.0.0.tgz
-    deps/yarn/external-test-npm-dep/test-npm-dep-1.0.0-external-gitcommit-b952715c0706f30d92a7253dcdadc510a618eca5.tgz: https://github.com/cachito-testing/test_files/raw/master/test-npm-dep-1.0.0.tgz
     deps/yarn/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
     deps/yarn/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/yarn/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
-  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@cfae8edfadcbcb384905f8bd11ef288ae41b560e"
+  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@e1cc10b76c580cdd6cbdfc83bf1692503385447e"
     dep_purls:
+    - "pkg:generic/cachito-yarn-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-yarn-without-deps.git%23da0a2888aa7aab37fec34c0b36d9e44560d2cf3e"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
+    - "pkg:npm/is-positive@3.1.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
+    - "pkg:generic/cachito-yarn-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-yarn-without-deps.git%23da0a2888aa7aab37fec34c0b36d9e44560d2cf3e"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
+    - "pkg:npm/is-positive@3.1.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
 # With yarn git-submodule
 git_submodule:
   repo: https://github.com/cachito-testing/git-submodule-yarn.git
-  ref: 387dd2f3297ec0253fecc8f13c7ea741127e78e0
+  ref: 7cbcabdf6fb506fe1e07a6e40f72a02293852565
   pkg_managers: ["yarn", "git-submodule"]
   packages:
     yarn: [{"path": "cachito-yarn-with-deps"}]
-  expected_files:
-    app: https://github.com/cachito-testing/git-submodule-yarn-tarball/tarball/a825151a968f84f38f93732724e4808f7e6e300c
-    deps/yarn/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
-    deps/yarn/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
-    deps/yarn/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
-    deps/yarn/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
-    deps/yarn/external-fecha/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-91680e4db1415fea33eac878cfd889c80a7b55c7.tgz
-    deps/yarn/external-npm-test-project/npm-test-project-1.0.0-external-gitcommit-88114c48d7d894f7e2306adf06137b096e9cdf29.tgz: https://github.com/cachito-testing/test_files/raw/master/npm-test-project-1.0.0.tgz
-    deps/yarn/external-test-npm-dep/test-npm-dep-1.0.0-external-gitcommit-b952715c0706f30d92a7253dcdadc510a618eca5.tgz: https://github.com/cachito-testing/test_files/raw/master/test-npm-dep-1.0.0.tgz
-    deps/yarn/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
-    deps/yarn/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
-    deps/yarn/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   response_expectations:
     dependencies:
       - dev: false
@@ -203,6 +189,11 @@ git_submodule:
         replaces: null
         type: yarn
         version: 1.1.0
+      - dev: false
+        name: cachito-yarn-without-deps
+        replaces: null
+        type: yarn
+        version: git+https://github.com/cachito-testing/cachito-yarn-without-deps.git#da0a2888aa7aab37fec34c0b36d9e44560d2cf3e
       - dev: false
         name: chai
         replaces: null
@@ -229,20 +220,15 @@ git_submodule:
         type: yarn
         version: 2.0.0
       - dev: false
-        name: npm-test-project
+        name: is-positive
         replaces: null
         type: yarn
-        version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+        version: 3.1.0
       - dev: false
         name: pathval
         replaces: null
         type: yarn
         version: 1.1.1
-      - dev: false
-        name: test-npm-dep
-        replaces: null
-        type: yarn
-        version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
       - dev: false
         name: type-detect
         replaces: null
@@ -253,13 +239,18 @@ git_submodule:
         name: cachito-yarn-with-deps
         path: cachito-yarn-with-deps
         type: git-submodule
-        version: https://github.com/cachito-testing/cachito-yarn-with-deps.git#693a1849708a7bcf2a0ef174786908a8cfbb236d
+        version: https://github.com/cachito-testing/cachito-yarn-with-deps.git#e1cc10b76c580cdd6cbdfc83bf1692503385447e
       - dependencies:
         - dev: false
           name: assertion-error
           replaces: null
           type: yarn
           version: 1.1.0
+        - dev: false
+          name: cachito-yarn-without-deps
+          replaces: null
+          type: yarn
+          version: git+https://github.com/cachito-testing/cachito-yarn-without-deps.git#da0a2888aa7aab37fec34c0b36d9e44560d2cf3e
         - dev: false
           name: chai
           replaces: null
@@ -286,20 +277,15 @@ git_submodule:
           type: yarn
           version: 2.0.0
         - dev: false
-          name: npm-test-project
+          name: is-positive
           replaces: null
           type: yarn
-          version: git+https://gitlab.com/eakhmano-test-group/eakhmano-test-subgroup/subsubgroup/npm-test-project.git#88114c48d7d894f7e2306adf06137b096e9cdf29
+          version: 3.1.0
         - dev: false
           name: pathval
           replaces: null
           type: yarn
           version: 1.1.1
-        - dev: false
-          name: test-npm-dep
-          replaces: null
-          type: yarn
-          version: git+https://elinah@bitbucket.org/elinah/test-npm-dep.git#b952715c0706f30d92a7253dcdadc510a618eca5
         - dev: false
           name: type-detect
           replaces: null
@@ -309,28 +295,38 @@ git_submodule:
         path: cachito-yarn-with-deps
         type: yarn
         version: 1.0.0
+  expected_files:
+    app: https://github.com/cachito-testing/git-submodule-yarn-tarball/tarball/f030b2a7f1eac1b65ce6c28228a35bcd6cbd4519
+    deps/yarn/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
+    deps/yarn/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
+    deps/yarn/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
+    deps/yarn/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
+    deps/yarn/external-fecha/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-91680e4db1415fea33eac878cfd889c80a7b55c7.tgz
+    deps/yarn/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
+    deps/yarn/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
+    deps/yarn/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
-  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@cfae8edfadcbcb384905f8bd11ef288ae41b560e"
-  - purl: "pkg:github/cachito-testing/git-submodule-yarn@387dd2f3297ec0253fecc8f13c7ea741127e78e0#cachito-yarn-with-deps"
+  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@e1cc10b76c580cdd6cbdfc83bf1692503385447e"
+  - purl: "pkg:github/cachito-testing/git-submodule-yarn@7cbcabdf6fb506fe1e07a6e40f72a02293852565#cachito-yarn-with-deps"
     dep_purls:
+    - "pkg:generic/cachito-yarn-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-yarn-without-deps.git%23da0a2888aa7aab37fec34c0b36d9e44560d2cf3e"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
+    - "pkg:npm/is-positive@3.1.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
+    - "pkg:generic/cachito-yarn-without-deps?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fcachito-testing%2Fcachito-yarn-without-deps.git%23da0a2888aa7aab37fec34c0b36d9e44560d2cf3e"
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
-    - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
-    - "pkg:generic/test-npm-dep?vcs_url=git%2Bhttps%3A%2F%2Felinah%40bitbucket.org%2Felinah%2Ftest-npm-dep.git%23b952715c0706f30d92a7253dcdadc510a618eca5"
     - "pkg:npm/assertion-error@1.1.0"
     - "pkg:npm/chai@4.2.0"
     - "pkg:npm/check-error@1.0.2"
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
+    - "pkg:npm/is-positive@3.1.0"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"

--- a/tests/integration/test_data/yarn_packages.yaml
+++ b/tests/integration/test_data/yarn_packages.yaml
@@ -32,7 +32,7 @@ without_deps:
 # content_manifest: PURLs for image contents part
 with_deps:
   repo: https://github.com/cachito-testing/cachito-yarn-with-deps.git
-  ref: 693a1849708a7bcf2a0ef174786908a8cfbb236d
+  ref: cfae8edfadcbcb384905f8bd11ef288ae41b560e
   pkg_managers: ["yarn"]
   response_expectations:
     dependencies:
@@ -142,7 +142,7 @@ with_deps:
         type: yarn
         version: 1.0.0
   expected_files:
-    app: https://github.com/cachito-testing/cachito-yarn-with-deps/tarball/693a1849708a7bcf2a0ef174786908a8cfbb236d
+    app: https://github.com/cachito-testing/cachito-yarn-with-deps/tarball/cfae8edfadcbcb384905f8bd11ef288ae41b560e
     deps/yarn/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
     deps/yarn/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
     deps/yarn/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
@@ -154,7 +154,7 @@ with_deps:
     deps/yarn/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/yarn/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
-  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@693a1849708a7bcf2a0ef174786908a8cfbb236d"
+  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@cfae8edfadcbcb384905f8bd11ef288ae41b560e"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"
     - "pkg:generic/npm-test-project?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Feakhmano-test-group%2Feakhmano-test-subgroup%2Fsubsubgroup%2Fnpm-test-project.git%2388114c48d7d894f7e2306adf06137b096e9cdf29"
@@ -185,7 +185,7 @@ git_submodule:
   packages:
     yarn: [{"path": "cachito-yarn-with-deps"}]
   expected_files:
-    app: https://github.com/cachito-testing/git-submodule-yarn-tarball/tarball/add02c1badd49b66570c1137cedb7a4d1ef73498
+    app: https://github.com/cachito-testing/git-submodule-yarn-tarball/tarball/a825151a968f84f38f93732724e4808f7e6e300c
     deps/yarn/assertion-error/assertion-error-1.1.0.tgz: https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz
     deps/yarn/chai/chai-4.2.0.tgz: https://registry.npmjs.org/chai/-/chai-4.2.0.tgz
     deps/yarn/check-error/check-error-1.0.2.tgz: https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz
@@ -310,7 +310,7 @@ git_submodule:
         type: yarn
         version: 1.0.0
   content_manifest:
-  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@693a1849708a7bcf2a0ef174786908a8cfbb236d"
+  - purl: "pkg:github/cachito-testing/cachito-yarn-with-deps@cfae8edfadcbcb384905f8bd11ef288ae41b560e"
   - purl: "pkg:github/cachito-testing/git-submodule-yarn@387dd2f3297ec0253fecc8f13c7ea741127e78e0#cachito-yarn-with-deps"
     dep_purls:
     - "pkg:generic/fecha?download_url=https%3A%2F%2Fgithub.com%2Ftaylorhakes%2Ffecha%2Farchive%2F91680e4db1415fea33eac878cfd889c80a7b55c7.tar.gz%23f09ea0b8115b9733dddc88227086c73ba4ddc926"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -308,7 +308,7 @@ def assert_elements_from_response(response_data, expected_response_data):
     """
     for element_name, expected_data in expected_response_data.items():
         assert response_data[element_name] == expected_data, (
-            f"#{response_data['id']}: elements in reponse differs from test expactations. \n"
+            f"#{response_data['id']}: elements in reponse differs from test expectations. \n"
             f"Response elements: "
             f"{json.dumps(response_data[element_name], indent=4, sort_keys=True)}, \n"
             f"Test expectations: {json.dumps(expected_data, indent=4, sort_keys=True)}"
@@ -393,7 +393,7 @@ def assert_content_manifest(client, request_id, image_contents):
     response_data = content_manifest_response.data
     assert_content_manifest_schema(response_data)
     assert image_contents == content_manifest_response.data["image_contents"], (
-        f"#{content_manifest_response.id}: image content in reponse differs from test expactations."
+        f"#{content_manifest_response.id}: image content in reponse differs from test expectations."
         f"\nResponse image content: "
         f"{json.dumps(content_manifest_response.data['image_contents'], indent=4, sort_keys=True)},"
         f"\nTest expectations: {json.dumps(image_contents, indent=4, sort_keys=True)}"


### PR DESCRIPTION
CLOUDBLD-8208
    
Cached dependencies tests data have changed, and we need to change
integration test yaml files to reflect this change.
    
Signed-off-by: Daniel Cho <dacho@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
