### PR TITLE
Change behavior of symlink check in the target repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,10 @@ with the `mod_auth_gssapi` module.
   environment variables for the completed request. Typically, you will only want to use this if your
   package *does* use C files, and the Cachito request is failing.
 
+* `remove-unsafe-symlinks` - the flag forces Cachito to remove all symlinks that points to some
+  location outside of a cloned repository. Otherwise, if the flag isn't set, Cachito will raise
+  a validation error right after cloning, in case when such symlinks are present in the source.
+
 ## Nexus
 
 ### Nexus For Java Script

--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -346,7 +346,11 @@ def create_request():
     error_callback = tasks.failed_request_callback.s(request.id)
     chain_tasks = [
         tasks.fetch_app_source.s(
-            request.repo, request.ref, request.id, "git-submodule" in pkg_manager_names
+            request.repo,
+            request.ref,
+            request.id,
+            "git-submodule" in pkg_manager_names,
+            any(flag.name == "remove-unsafe-symlinks" for flag in request.flags),
         ).on_error(error_callback)
     ]
 

--- a/cachito/web/migrations/versions/01bb0873ddcb_add_the_remove_unsafe_symlinks_flag.py
+++ b/cachito/web/migrations/versions/01bb0873ddcb_add_the_remove_unsafe_symlinks_flag.py
@@ -1,0 +1,45 @@
+"""Add the remove-unsafe-symlinks flag
+
+Revision ID: 01bb0873ddcb
+Revises: 02229e089b24
+Create Date: 2022-03-15 15:31:11.301867
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "01bb0873ddcb"
+down_revision = "02229e089b24"
+branch_labels = None
+depends_on = None
+
+
+flag_table = sa.Table(
+    "flag",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer(), primary_key=True),
+    sa.Column("name", sa.String(), nullable=False),
+    sa.Column("active", sa.Boolean(), nullable=False, default=True),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    res = connection.execute(
+        flag_table.select().where(flag_table.c.name == "remove-unsafe-symlinks")
+    ).fetchone()
+    if res is None:
+        connection.execute(flag_table.insert().values(name="remove-unsafe-symlinks", active=True))
+    else:
+        connection.execute(
+            flag_table.update()
+            .where(flag_table.c.name == "remove-unsafe-symlinks")
+            .values(active=True)
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute(flag_table.update().values(name="remove-unsafe-symlinks", active=False))

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -162,6 +162,7 @@ def test_create_and_fetch_request(
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
             "git-submodule" in expected_pkg_managers,
+            False,
         ).on_error(error_callback)
     ]
     if "gomod" in expected_pkg_managers:
@@ -220,6 +221,7 @@ def test_create_request_with_gomod_package_configs(
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
             False,
+            False,
         ).on_error(error_callback),
         fetch_gomod_source.si(1, [], package_value["gomod"]).on_error(error_callback),
         process_fetched_sources.si(1).on_error(error_callback),
@@ -249,6 +251,7 @@ def test_create_request_with_npm_package_configs(
             "https://github.com/release-engineering/web-terminal.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
+            False,
             False,
         ).on_error(error_callback),
         fetch_npm_source.si(1, package_value["npm"]).on_error(error_callback),
@@ -290,6 +293,7 @@ def test_create_request_with_pip_package_configs(mock_chain, app, auth_env, clie
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
             False,
+            False,
         ).on_error(error_callback),
         fetch_pip_source.si(1, package_value["pip"]).on_error(error_callback),
         process_fetched_sources.si(1).on_error(error_callback),
@@ -319,6 +323,7 @@ def test_create_request_with_yarn_package_configs(
             "https://github.com/release-engineering/web-terminal.git",
             "c50b93a32df1c9d700e3e80996845bc2e13be848",
             1,
+            False,
             False,
         ).on_error(error_callback),
         fetch_yarn_source.si(1, package_value["yarn"]).on_error(error_callback),
@@ -371,6 +376,7 @@ def test_create_and_fetch_request_with_flag(mock_chain, app, auth_env, client, d
                 "https://github.com/release-engineering/retrodep.git",
                 "c50b93a32df1c9d700e3e80996845bc2e13be848",
                 1,
+                False,
                 False,
             ).on_error(error_callback),
             fetch_gomod_source.si(1, [], []).on_error(error_callback),


### PR DESCRIPTION
CLOUDBLD-8960

The patch makes possible to process repository even if there are present
symlinks that points outside the repo.
Instead of raising exception Cachito will remove that links.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
