### PR TITLE
Run go list with -mod=readonly when not vendoring

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -293,12 +293,18 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
             )
             _merge_bundle_dirs(tmp_download_cache_dir, str(bundle_dir.gomod_download_dir))
 
+        if not should_vendor:
+            # Make Go ignore the vendor dir even if there is one
+            go_list = ["go", "list", "-mod", "readonly"]
+        else:
+            go_list = ["go", "list"]
+
         log.info("Retrieving the list of packages")
-        package_list = run_gomod_cmd(["go", "list", "-find", "./..."], run_params).splitlines()
+        package_list = run_gomod_cmd([*go_list, "-find", "./..."], run_params).splitlines()
 
         log.info("Retrieving the list of package level dependencies")
         package_info = _load_list_deps(
-            run_gomod_cmd(["go", "list", "-e", "-deps", "-json", "./..."], run_params)
+            run_gomod_cmd([*go_list, "-e", "-deps", "-json", "./..."], run_params)
         )
 
         packages = []

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -307,6 +307,9 @@ def test_resolve_gomod(
         if dep_replacement:
             assert mock_run.call_args_list[2][0][0] == ("go", "mod", "tidy")
 
+    # when not vendoring, go list should be called with -mod readonly
+    assert mock_run.call_args_list[-2][0][0] == ["go", "list", "-mod", "readonly", "-find", "./..."]
+
     for call in mock_run.call_args_list:
         env = call.kwargs["env"]
         if cgo_disable:
@@ -378,6 +381,8 @@ def test_resolve_gomod_vendor_dependencies(
     gomod = resolve_gomod(archive_path, request)
 
     assert mock_run.call_args_list[0][0][0] == ("go", "mod", "vendor")
+    # when vendoring, go list should be called without -mod readonly
+    assert mock_run.call_args_list[-2][0][0] == ["go", "list", "-find", "./..."]
     assert gomod["module"] == sample_package
     assert not gomod["module_deps"]
 


### PR DESCRIPTION
CLOUDBLD-8966

When not vendoring, pass the -mod=readonly flag to make Go behave
accordingly - even if a vendor directory is present, we ignore it.

When we *are* vendoring, do not pass any flags and rely on Go's own
logic to decide if it should use -mod=vendor or something else.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
