### PR TITLE
Revert "Enable cachito_gomod_strict_vendor flag by default"

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -34,7 +34,7 @@ class Config(object):
     cachito_deps_patch_batch_size = 50
     cachito_gomod_download_max_tries = 5
     cachito_gomod_ignore_missing_gomod_file = True
-    cachito_gomod_strict_vendor = True
+    cachito_gomod_strict_vendor = False
     cachito_log_level = "INFO"
     cachito_js_download_batch_size = 30
     cachito_nexus_ca_cert = "/etc/cachito/nexus_ca.pem"

--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -6,7 +6,7 @@ api_auth_type: null
 # Time in minutes at which the request must be completed
 timeout: 45
 # The flag cachito_gomod_strict_vendor is enabled on the environment
-strict_mode_enabled: true
+strict_mode_enabled: false
 # Package that will be used for testing
 packages:
   # repo: The URL for the upstream git repository

--- a/tests/integration/test_gomod_packages.py
+++ b/tests/integration/test_gomod_packages.py
@@ -26,8 +26,7 @@ def test_gomod_vendor_without_flag(test_env):
         assert completed_response.status == 200
         assert completed_response.data["state"] == "failed"
         error_msg = (
-            'The "gomod-vendor" or "gomod-vendor-check" flag must be set when your repository has '
-            "vendored dependencies."
+            'The "gomod-vendor" flag must be set when your repository has vendored dependencies'
         )
         assert error_msg in completed_response.data["state_reason"], (
             f"#{completed_response.id}: Request failed correctly, but with unexpected message: "

--- a/tests/integration/test_gomod_packages.py
+++ b/tests/integration/test_gomod_packages.py
@@ -26,7 +26,8 @@ def test_gomod_vendor_without_flag(test_env):
         assert completed_response.status == 200
         assert completed_response.data["state"] == "failed"
         error_msg = (
-            'The "gomod-vendor" flag must be set when your repository has vendored dependencies'
+            'The "gomod-vendor" or "gomod-vendor-check" flag must be set when your repository has '
+            "vendored dependencies."
         )
         assert error_msg in completed_response.data["state_reason"], (
             f"#{completed_response.id}: Request failed correctly, but with unexpected message: "

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -3,6 +3,7 @@ import os
 import re
 import tarfile
 import textwrap
+from contextlib import nullcontext
 from tempfile import TemporaryDirectory as tempDir
 from textwrap import dedent
 from unittest import mock
@@ -394,22 +395,34 @@ def test_resolve_gomod_vendor_dependencies(
 
 @mock.patch("cachito.workers.pkg_managers.gomod.GoCacheTemporaryDirectory")
 @mock.patch("subprocess.run")
+@mock.patch("cachito.workers.pkg_managers.gomod.get_golang_version")
 @mock.patch("cachito.workers.pkg_managers.gomod.get_worker_config")
 @mock.patch("pathlib.Path.is_dir")
+@pytest.mark.parametrize("strict_vendor", [True, False])
 def test_resolve_gomod_strict_mode_raise_error(
-    mock_isdir, mock_gwc, mock_run, mock_temp_dir, tmpdir
+    mock_isdir, mock_gwc, mock_golang_version, mock_run, mock_temp_dir, tmpdir, strict_vendor,
 ):
     mock_isdir.return_value = True
     # Mock the get_worker_config
     mock_config = mock.Mock()
-    mock_config.cachito_gomod_strict_vendor = True
+    if strict_vendor != "default":
+        mock_config.cachito_gomod_strict_vendor = strict_vendor
     mock_config.cachito_athens_url = "http://athens:3000"
     mock_gwc.return_value = mock_config
     # Mock the tempfile.TemporaryDirectory context manager
     mock_temp_dir.return_value.__enter__.return_value = str(tmpdir)
+    mock_golang_version.return_value = "v2.1.1"
 
     # Mock the "subprocess.run" call
-    mock_run.return_value = mock.Mock(returncode=0, stdout=None)  # go mod edit -replace
+    mock_run.side_effect = [
+        mock.Mock(returncode=0, stdout=""),  # go mod edit -replace
+        mock.Mock(returncode=0, stdout=""),  # go mod download
+        mock.Mock(returncode=0, stdout=""),  # go mod tidy
+        mock.Mock(returncode=0, stdout="pizza"),  # go list -m
+        mock.Mock(returncode=0, stdout="pizza v1.0.0 => pizza v1.0.1\n"),  # go list -mod readonly
+        mock.Mock(returncode=0, stdout=""),  # go list -find
+        mock.Mock(returncode=0, stdout=""),  # go list -deps -json
+    ]
 
     archive_path = "/this/is/path/to/archive.tar.gz"
     request = {"id": 3, "ref": "c50b93a32df1c9d700e3e80996845bc2e13be848"}
@@ -417,7 +430,7 @@ def test_resolve_gomod_strict_mode_raise_error(
         'The "gomod-vendor" or "gomod-vendor-check" flag must be set when your repository has '
         "vendored dependencies."
     )
-    with pytest.raises(CachitoError, match=expected_error):
+    with strict_vendor and pytest.raises(CachitoError, match=expected_error) or nullcontext():
         resolve_gomod(
             archive_path, request, [{"name": "pizza", "type": "gomod", "version": "v1.0.0"}]
         )


### PR DESCRIPTION
CLOUDBLD-8966

This reverts commit 818ec8a4810b0e12879380c96bb90d2f62cc633e.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
