### PR TITLE
Apply blobless cloning to reduce utilization of disk space by source archives

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -158,6 +158,7 @@ class Git(SCM):
                     self.url,
                     clone_path,
                     no_checkout=True,
+                    filter="blob:none",
                     # Don't allow git to prompt for a username if we don't have access
                     env={"GIT_TERMINAL_PROMPT": "0"},
                 )

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -76,7 +76,11 @@ def test_clone_and_archive(
     assert mock_temp_dir.return_value.__enter__.call_count == 2
     # Verify the repo was cloned and checked out properly
     mock_clone.assert_called_once_with(
-        url, "/tmp/cachito-temp/repo", no_checkout=True, env={"GIT_TERMINAL_PROMPT": "0"}
+        url,
+        "/tmp/cachito-temp/repo",
+        no_checkout=True,
+        filter="blob:none",
+        env={"GIT_TERMINAL_PROMPT": "0"},
     )
     assert mock_clone.return_value.head.reference == mock_commit
     mock_clone.return_value.head.reset.assert_called_once_with(index=True, working_tree=True)

--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,9 @@ basepython = python3.8
 description = black checks [Mandatory]
 skip_install = true
 deps =
-    # Pin the version of black to avoid a newer version causing tox to fail
+    # Pin the version of black and click to avoid a newer version causing tox to fail
     black==19.10b0
+    click==8.0.3
 commands =
     black --check --diff cachito tests
     # Use shorter line length for scripts


### PR DESCRIPTION
CLOUDBLD-9254

Add --filter=blob:none parameter to 'git clone'.
The parameter allows to speed up cloning and significantly save disk space for source archives.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
