### PR TITLE
Set Cloud Runtime provider to JSON in config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       ATHENS_DISK_STORAGE_ROOT: /var/lib/athens
       ATHENS_STORAGE_TYPE: disk
       ATHENS_GO_BINARY_ENV_VARS: GOSUMDB=off
+      ATHENS_CLOUD_RUNTIME: JSON
     volumes:
       - athens-storage:/var/lib/athens:z
     ports:


### PR DESCRIPTION
Current logs in Athens run in developer mode and they do not provide information about the
day or timezone.

CLOUDBLD-6488

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
