### PR TITLE
Accomodating https://issues.sonatype.org/browse/NEXUS-25162, required…

### DIFF
--- a/cachito/workers/nexus_scripts/pip_before_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/pip_before_content_staged.groovy
@@ -12,7 +12,7 @@ import groovy.transform.Field
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.sonatype.nexus.repository.config.Configuration
-import org.sonatype.nexus.repository.storage.WritePolicy
+import org.sonatype.nexus.repository.config.WritePolicy
 
 
 // Scope logger to the script using @Field

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - 3000:3000
 
   nexus:
-    image: sonatype/nexus3:3.27.0
+    image: sonatype/nexus3:3.38.1
     environment:
       # Enable the script API. This is disabled by default in 3.21.2+.
       INSTALL4J_ADD_VM_PARAMS: -Dnexus.scripts.allowCreation=true -Dstorage.diskCache.diskFreeSpaceLimit=512


### PR DESCRIPTION
… to support Nexux >= 3.28.0

Signed-off-by: Mike Kingsbury <mike.kingsbury@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
