### PR TITLE
Re-attempt to delete bundle directory when state is set to 'stale'

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -499,7 +499,7 @@ def patch_request(request_id):
             for pkg_manager in ["npm", "pip", "yarn"]:
                 if any(p.name == pkg_manager for p in request.pkg_managers):
                     cleanup_nexus.append(pkg_manager)
-        delete_bundle_temp = new_state in ("complete", "failed")
+        delete_bundle_temp = new_state in ("complete", "failed", "stale")
         delete_logs = new_state == "stale"
         new_state_reason = payload["state_reason"]
         # This is to protect against a Celery task getting executed twice and setting the


### PR DESCRIPTION
CLOUDBLD-9254

The change covers two cases:
1) Deleting of bundle dir failed due some volatile cause, so re-attempting
   would help to cleanup that eventually.
2) Some request stuck in 'in_progress' state. As result, 'complete' or 'failed'
   state is missed and deleting of the bundle dir wasn't triggered.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
