### PR TITLE
Fix an error condition when cloned_main_repo isn't properly set

### DIFF
--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -115,7 +115,7 @@ class TestCachedDependencies:
 
     def teardown_method(self, method):
         """Delete branch with commit in the main repo."""
-        if not self.use_local:
+        if (not self.use_local) and self.cloned_main_repo:
             delete_branch_and_check(
                 self.branch, self.cloned_main_repo, self.main_repo_origin, [self.main_repo_commit]
             )


### PR DESCRIPTION
When the TestCachedDependencies integration test failed before setting the [cloned_main_repo](https://github.com/containerbuildsystem/cachito/blob/03d2553e91edac9c52ecd8f3d121b9aa2414d3d0/tests/integration/test_using_cached_dependencies.py#L196) variable, the teardown method would also fail and cover up the actual root cause.

# Maintainers will complete the following section

- [x ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
