### PR TITLE
Validate string length to repo field on create_request endpoint

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -33,6 +33,7 @@ from cachito.web.models import (
     RequestState,
     RequestStateMapping,
     is_request_ref_valid,
+    is_request_repo_valid,
 )
 from cachito.web.status import status
 from cachito.web.utils import deep_sort_icm, normalize_end_date, pagination_metadata, str_to_bool
@@ -103,11 +104,13 @@ def get_requests():
         query = query.filter(RequestState.state == state_int)
     repo = flask.request.args.get("repo")
     if repo:
+        if not is_request_repo_valid(repo):
+            raise ValidationError('The "repo" parameter must be shorter than 200 characters')
         query = query.filter(Request.repo == repo)
     ref = flask.request.args.get("ref")
     if ref:
         if not is_request_ref_valid(ref):
-            raise ValidationError(f"{ref} is not a valid ref.")
+            raise ValidationError('The "ref" parameter must be a 40 character hex string')
         query = query.filter(Request.ref == ref)
     pkg_managers = flask.request.args.getlist("pkg_manager")
     if pkg_managers:

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -26,6 +26,11 @@ def is_request_ref_valid(ref: str) -> bool:
     return re.match(r"^[a-f0-9]{40}$", ref) is not None
 
 
+def is_request_repo_valid(repo: str) -> bool:
+    """Check if a string is a valid repo in the expected size."""
+    return len(repo) <= 200
+
+
 request_pkg_manager_table = db.Table(
     "request_pkg_manager",
     db.Column("request_id", db.Integer, db.ForeignKey("request.id"), index=True, nullable=False),
@@ -477,6 +482,9 @@ class Request(db.Model):
 
         if not is_request_ref_valid(kwargs["ref"]):
             raise ValidationError('The "ref" parameter must be a 40 character hex string')
+
+        if not is_request_repo_valid(kwargs["repo"]):
+            raise ValidationError('The "repo" parameter must be shorter than 200 characters')
 
         request_kwargs = deepcopy(kwargs)
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -2193,6 +2193,11 @@ def test_get_content_manifests_by_requests(app, client, db, auth_env, tmpdir):
     [
         ["repo=https://github.com/org/bar.git", 1, ["https://github.com/org/bar.git"]],
         [
+            "repo=https://github.com/org/" + ("bar" * 100) + ".git",
+            None,
+            'The \\"repo\\" parameter must be shorter than 200 characters',
+        ],
+        [
             "repo=",
             3,
             [
@@ -2211,7 +2216,7 @@ def test_get_content_manifests_by_requests(app, client, db, auth_env, tmpdir):
                 "https://github.com/org/foo.git",
             ],
         ],
-        ["ref=a-git-ref", None, "a-git-ref is not a valid ref"],
+        ["ref=a-git-ref", None, 'The \\"ref\\" parameter must be a 40 character hex string'],
         [
             "pkg_manager=gomod",
             2,


### PR DESCRIPTION
CLOUDBLD-7050

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
