### PR TITLE
Fix deprecated function calls warnings when running tests

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -264,11 +264,12 @@ def download_archive(request_id):
     flask.current_app.logger.info(
         "Sending the bundle at %s for request %d", bundle_dir.bundle_archive_file, request_id
     )
+
     resp = flask.send_file(
         str(bundle_dir.bundle_archive_file),
         mimetype="application/gzip",
         as_attachment=True,
-        attachment_filename=f"cachito-{request_id}.tar.gz",
+        download_name=f"cachito-{request_id}.tar.gz",
     )
     resp.headers["Digest"] = f"sha-256={b64encode(bytes.fromhex(store_checksum))}"
     return resp

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -693,7 +693,7 @@ def _get_golang_pseudo_version(commit, tag=None, module_major_version=None, subp
         # vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdefabcdef is used when the most recent versioned commit
         # before the target commit is vX.Y.Z
         version_seperator = "-"
-        pseudo_semantic_version = semver.bump_patch(str(tag_semantic_version))
+        pseudo_semantic_version = tag_semantic_version.bump_patch()
 
     return f"v{pseudo_semantic_version}{version_seperator}0.{commit_timestamp}-{commit_hash}"
 
@@ -782,7 +782,7 @@ def _get_semantic_version_from_tag(tag_name, subpath=None):
     else:
         semantic_version = tag_name[1:]
 
-    return semver.parse_version_info(semantic_version)
+    return semver.VersionInfo.parse(semantic_version)
 
 
 def get_golang_version(module_name, git_path, commit_sha, update_tags=False, subpath=None):


### PR DESCRIPTION
CLOUDBLD-9071

Signed-off-by: Felipe Campos <fepas.unb@gmail.com>

This PR will switch the following deprecated methods/parameters for a stable version:
 - `attachment_filename` -> `download_name`
 - `semver.parse_version_info` -> `semver.VersionInfo.parse`
 - `semver.bump_patch(str(tag_semantic_version))` -> `semver.VersionInfo.bump_patch(tag_semantic_version)` 
 _(also removing the `str` function on this, is not necessary in this case anymore.)_
 
 Warnings before:

![before-fix](https://user-images.githubusercontent.com/29442029/170526258-1b79c427-3a9d-49e4-a7ba-9554b28fb9b5.png)

 
 Warnings now:

![after-fix](https://user-images.githubusercontent.com/29442029/170526266-b72edf75-1774-4201-9348-3d6a383fedc1.png)





# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
