### PR TITLE
Add resources to setup ephemeral Ruby repositories

### DIFF
--- a/cachito/workers/nexus_scripts/rubygems_before_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/rubygems_before_content_staged.groovy
@@ -1,0 +1,60 @@
+/*
+This script configures Nexus so that Cachito can stage Rubygems content for the Cachito request.
+
+This script creates a Rubygems hosted repository and a raw repository to be used by a Cachito
+request to fetch Ruby content
+
+No permissions are configured since it is expected that Cachito's Nexus service account has access
+to use all Ruby related repositories managed by the Nexus instance.
+ */
+import groovy.json.JsonSlurper
+import groovy.transform.Field
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.sonatype.nexus.repository.config.Configuration
+import org.sonatype.nexus.repository.config.WritePolicy
+
+
+// Scope logger to the script using @Field
+@Field final Logger logger = LoggerFactory.getLogger('cachito');
+
+
+def createHostedRepo(String name, String repoType) {
+    WritePolicy writePolicy = WritePolicy.ALLOW_ONCE
+    Boolean strictContentValidation = true
+    String blobStoreName = "cachito-ruby"
+    // repository is an object that is injected by Nexus when the script is executed
+    if(repository.repositoryManager.exists(name)) {
+        logger.info("Modifying the hosted repository ${name}")
+        Configuration hostedRepoConfig = repository.repositoryManager.get(name).configuration
+        def storage = hostedRepoConfig.attributes('storage')
+        storage.set('strictContentTypeValidation', strictContentValidation)
+        storage.set('writePolicy', writePolicy)
+        repository.repositoryManager.update(hostedRepoConfig)
+    }
+    else {
+        logger.info("Creating the hosted ${repoType} repository ${name}")
+        switch(repoType) {
+            case "raw":
+                repository.createRawHosted(name, blobStoreName, strictContentValidation, writePolicy)
+                break;
+            case "rubygems":
+                repository.createRubygemsHosted(name, blobStoreName, strictContentValidation, writePolicy)
+                break;
+            default:
+                logger.warn("Type ${repoType} not supported. repository ${name} not created.")
+                break;
+        }
+    }
+}
+
+
+request = new JsonSlurper().parseText(args)
+['rubygems_repository_name', 'raw_repository_name'].each { param ->
+    assert request.get(param): "The ${param} parameter is required"
+}
+
+createHostedRepo(request.rubygems_repository_name, "rubygems")
+createHostedRepo(request.raw_repository_name, "raw")
+
+return 'The repositories were created successfully'

--- a/cachito/workers/pkg_managers/rubygems.py
+++ b/cachito/workers/pkg_managers/rubygems.py
@@ -1,0 +1,27 @@
+import logging
+
+from cachito.errors import CachitoError
+from cachito.workers import nexus
+from cachito.workers.errors import NexusScriptError
+
+log = logging.getLogger(__name__)
+
+
+def prepare_nexus_for_rubygems_request(rubygems_repo_name, raw_repo_name):
+    """
+    Prepare Nexus so that Cachito can stage Rubygems content.
+
+    :param str rubygems_repo_name: the name of the Rubygems repository for the request
+    :param str raw_repo_name: the name of the raw repository for the request
+    :raise CachitoError: if the script execution fails
+    """
+    payload = {
+        "rubygems_repository_name": rubygems_repo_name,
+        "raw_repository_name": raw_repo_name,
+    }
+    script_name = "rubygems_before_content_staged"
+    try:
+        nexus.execute_script(script_name, payload)
+    except NexusScriptError:
+        log.exception("Failed to execute the script %s", script_name)
+        raise CachitoError("Failed to prepare Nexus for Cachito to stage Rubygems content")

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -271,6 +271,7 @@ def test_create_or_update_scripts(mock_cous):
         "pip_after_content_staged",
         "pip_before_content_staged",
         "pip_cleanup",
+        "rubygems_before_content_staged",
     }
     for call_args in mock_cous.call_args_list:
         script_name = call_args[0][0]

--- a/tests/test_workers/test_pkg_managers/test_rubygems.py
+++ b/tests/test_workers/test_pkg_managers/test_rubygems.py
@@ -1,0 +1,37 @@
+from unittest import mock
+
+import pytest
+
+from cachito.errors import CachitoError
+from cachito.workers.errors import NexusScriptError
+from cachito.workers.pkg_managers import rubygems
+
+
+class TestNexus:
+    """Nexus related tests."""
+
+    @mock.patch("cachito.workers.pkg_managers.rubygems.nexus.execute_script")
+    def test_prepare_nexus_for_rubygems_request(self, mock_exec_script):
+        """Check whether groovy script is called with proper args."""
+        rubygems.prepare_nexus_for_rubygems_request(
+            "cachito-rubygems-hosted-1", "cachito-rubygems-raw-1"
+        )
+
+        mock_exec_script.assert_called_once_with(
+            "rubygems_before_content_staged",
+            {
+                "rubygems_repository_name": "cachito-rubygems-hosted-1",
+                "raw_repository_name": "cachito-rubygems-raw-1",
+            },
+        )
+
+    @mock.patch("cachito.workers.pkg_managers.rubygems.nexus.execute_script")
+    def test_prepare_nexus_for_rubygems_request_failed(self, mock_exec_script):
+        """Check whether proper error is raised on groovy script failures."""
+        mock_exec_script.side_effect = NexusScriptError()
+
+        expected = "Failed to prepare Nexus for Cachito to stage Rubygems content"
+        with pytest.raises(CachitoError, match=expected):
+            rubygems.prepare_nexus_for_rubygems_request(
+                "cachito-rubygems-hosted-1", "cachito-rubygems-raw-1"
+            )


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
