### PR TITLE
Catch proper exceptions and/or unconceal Cachito exceptions

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -537,7 +537,7 @@ def patch_request(request_id):
             bundle_dir.bundle_archive_file.unlink()
             bundle_dir.bundle_archive_checksum.unlink()
             bundle_dir.packages_data.unlink()
-        except:  # noqa E722
+        except OSError:
             flask.current_app.logger.exception(
                 "Failed to delete the bundle archive %s", bundle_dir.bundle_archive_file
             )
@@ -548,9 +548,13 @@ def patch_request(request_id):
         )
         try:
             bundle_dir.rmtree()
-        except:  # noqa E722
+        except OSError:
             flask.current_app.logger.exception(
-                "Failed to delete the temporary files at %s", bundle_dir
+                "Failed to delete the temporary files (OSError) at %s", bundle_dir
+            )
+        except Exception as ex:
+            flask.current_app.logger.exception(
+                "Failed to delete the temporary files (%s) at %s", type(ex).__name__, bundle_dir
             )
 
     if delete_logs:
@@ -558,7 +562,7 @@ def patch_request(request_id):
         path_to_file = os.path.join(request_log_dir, f"{request_id}.log")
         try:
             os.remove(path_to_file)
-        except:  # noqa E722
+        except OSError:
             flask.current_app.logger.exception("Failed to delete the log file %s", path_to_file)
 
     for pkg_mgr in cleanup_nexus:

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -813,8 +813,12 @@ def get_golang_version(module_name, git_path, commit_sha, update_tags=False, sub
     if update_tags:
         try:
             repo.remote().fetch(force=True, tags=True)
-        except:  # noqa E722
-            log.warning("Failed to fetch the tags on the Git repository for %s", module_name)
+        except Exception as ex:
+            raise CachitoError(
+                "Failed to fetch the tags on the Git repository (%s) for %s ",
+                type(ex).__name__,
+                module_name,
+            )
 
     if module_major_version:
         major_versions_to_try = (module_major_version,)

--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -57,10 +57,16 @@ class Git(SCM):
         try:
             repo.head.reference = repo.commit(self.ref)
             repo.head.reset(index=True, working_tree=True)
-        except:  # noqa E722
-            log.exception('Checking out the Git ref "%s" failed', self.ref)
+
+        except Exception as ex:
+            log.exception(
+                "Failed on checking out the Git ref %s, url: %s, exception: %s",
+                self.ref,
+                self.url,
+                type(ex).__name__,
+            )
             raise CachitoError(
-                "Checking out the Git repository failed. Please verify the supplied reference "
+                "Failed on checking out the Git repository. Please verify the supplied reference "
                 f'of "{self.ref}" is valid.'
             )
 
@@ -162,9 +168,14 @@ class Git(SCM):
                     # Don't allow git to prompt for a username if we don't have access
                     env={"GIT_TERMINAL_PROMPT": "0"},
                 )
-            except:  # noqa E722
-                log.exception("Cloning the Git repository from %s failed", self.url)
-                raise CachitoError("Cloning the Git repository failed")
+            except Exception as ex:
+                log.exception(
+                    "Failed cloning the Git repository from %s, ref: %s, exception: %s",
+                    self.url,
+                    self.ref,
+                    type(ex).__name__,
+                )
+                raise CachitoError("Failed cloning the Git repository")
 
             self._reset_git_head(repo)
 
@@ -192,8 +203,14 @@ class Git(SCM):
                 # The reference must be specified to handle commits which are not part
                 # of a branch.
                 repo.remote().fetch(refspec=self.ref)
-            except:  # noqa E722
-                log.exception("Failed to fetch from remote %s", self.url)
+
+            except Exception as ex:
+                log.exception(
+                    "Failed to fetch from remote %s, ref: %s, exception: %s",
+                    self.url,
+                    self.ref,
+                    type(ex).__name__,
+                )
                 raise CachitoError("Failed to fetch from the remote Git repository")
 
             self._reset_git_head(repo)

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -107,7 +107,7 @@ def test_clone_and_archive_clone_failed(mock_git_clone, mock_temp_dir, gitsubmod
     mock_git_clone.side_effect = git.GitCommandError("some error", 1)
 
     git_obj = scm.Git(url, ref)
-    with pytest.raises(CachitoError, match="Cloning the Git repository failed"):
+    with pytest.raises(CachitoError, match="Failed cloning the Git repository"):
         git_obj.clone_and_archive(gitsubmodule)
 
 
@@ -122,8 +122,8 @@ def test_clone_and_archive_checkout_failed(mock_git_clone, mock_temp_dir, gitsub
 
     git_obj = scm.Git(url, ref)
     expected = (
-        "Checking out the Git repository failed. Please verify the supplied reference of "
-        f'"{ref}" is valid.'
+        "Failed on checking out the Git repository. Please verify the supplied reference "
+        f'of "{ref}" is valid.'
     )
     with mock.patch.object(git_obj.sources_dir, "archive_path", new=archive_path):
         with pytest.raises(CachitoError, match=expected):


### PR DESCRIPTION
[CLOUDBLD-2833](https://issues.redhat.com/browse/CLOUDBLD-2833)

Signed-off-by: Felipe Campos <fepas.unb@gmail.com>

This issue is about fixing the blocks with the "noqa E722" comment. This was necessary because of the bare exceptions that we were using, which can cause the exceptions to be not seen. 

I found it very difficult to track down all possible exceptions that could happen in some cases, so I thought of another solution.

This is the most basic approach that I found to improve it: changing the bare except to an exception with an associated value, where we can log the exception name and its details. 

Example: 

```py
except:  # noqa E722
  flask.current_app.logger.exception(
    "Failed to delete the bundle archive %s", bundle_dir.bundle_archive_file
  )
```

It turns into:
```py
except Exception as ex:
  template = "An exception of type {0} occurred. Arguments:\n{1!r}"
  flask.current_app.logger.exception(template.format(type(ex).__name__, ex.args))
  flask.current_app.logger.exception(
    "Failed to delete the bundle archive %s", bundle_dir.bundle_archive_file
  )
```
Maybe that's not what is expected to solve this problem (also the acceptance criteria define that I should also change the API response to show the type of exception), so I'm opening this pull request to ask for your advice. :D

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
