### PR TITLE
Make sure that cachito saves UTC time to DB records

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-
+import datetime
 from typing import Optional
 from unittest import mock
 
@@ -52,3 +52,13 @@ class TestRequest:
             request.content_manifest.to_json()
 
         assert load_mock.call_count == call_count
+
+    def test_utcnow(self, app, auth_env):
+        request = self._create_request_object()
+        request.add_state(RequestStateMapping.complete.name, "Complete")
+        current_utc_datetime = datetime.datetime.utcnow()
+        request_created_datetime = request.created
+        diff_in_secs = (current_utc_datetime - request_created_datetime).total_seconds()
+
+        # Difference between "created" and current UTC datetimes is within 10 seconds
+        assert abs(diff_in_secs) <= 10


### PR DESCRIPTION
CLOUDBLD-7633

Signed-off-by: Sumin Cho <sucho@redhat.com>

**Problem**
Currently, Cachito depends on pods with UTC timezone. If there is a situation in which some pods are set in non-UTC timezones, this will produce inconsistency in the DB. Time-sensitive endpoints such as `created` and `updated` values should be based on one timezone, UTC, as the DB schema is "timestamp without timezone".

Right now, we are using the function `sqlalchemy.func.now()` to set the current DateTime for the `created` and `updated` values in a Cachito request. The problem with this function is that the timezone is based on the DB pod's timezone (which may or may not be UTC).

**Solution**
We can utilize our DB compilers, PostgreSQL and SQLite (for testing environments), to always generate the current UTC timestamp regardless of the pods' timezones.

By following this [implementation](https://docs.sqlalchemy.org/en/14/core/compiler.html#utc-timestamp-function) from the SQLAlchemy documentation, we can make a class for `utcnow` which will use compiler functions in the PostgreSQL and SQLite databases. This way, no matter which database we are using, we can generate the current UTC timestamps from the databases and properly set the `created` and `updated` endpoints for all requests.

**Doubts I have currently:**

- Where should I place the `utcnow` and its compile functions? Should I put this at the end of the file? Should I make a new file for this?
- Is the unit test reliable? Is there a better, simpler way to go about testing this?

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
