### PR TITLE
Remove "created" field from Request parameters

### DIFF
--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -459,7 +459,6 @@ class Request(db.Model):
         # Validate all required parameters are present
         required_params = {"repo", "ref"}
         optional_params = {
-            "created",
             "dependency_replacements",
             "flags",
             "packages",

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -1008,9 +1008,6 @@ components:
             The user this request is created on behalf of. This is reserved for privileged users
             that can act as a representative.
           example: tbrady@DOMAIN.LOCAL
-        created:
-          type: string
-          example: "2019-09-17T18:52:57.577851"
       required:
       - ref
       - repo


### PR DESCRIPTION
CLOUDBLD-10190

Signed-off-by: Sumin Cho <sucho@redhat.com>

**Problem**
Currently, the "created" field is a valid parameter for input in a Cachito request. However, this causes inconsistency in the DB because requests contain time-sensitive values to be filtered and organized.

The problem lies in the `from_json` method, as `created` is part of the `optional_params` list. There also is not a test for checking if invalid parameters to a Cachito request raises a `ValidationError`.

**Solution**

- Get rid of `created` field in `optional_params`
- Get rid of `created` field in "Create a new Request" section in the API documentation
- Add unit test to check if invalid parameters are set in a Cachito request.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
