### PR TITLE
Change Cachito test env var after enabling strict mode

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -34,7 +34,7 @@ class Config(object):
     cachito_deps_patch_batch_size = 50
     cachito_gomod_download_max_tries = 5
     cachito_gomod_ignore_missing_gomod_file = True
-    cachito_gomod_strict_vendor = False
+    cachito_gomod_strict_vendor = True
     cachito_log_level = "INFO"
     cachito_js_download_batch_size = 30
     cachito_nexus_ca_cert = "/etc/cachito/nexus_ca.pem"

--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -6,7 +6,7 @@ api_auth_type: null
 # Time in minutes at which the request must be completed
 timeout: 45
 # The flag cachito_gomod_strict_vendor is enabled on the environment
-strict_mode_enabled: false
+strict_mode_enabled: true
 # Package that will be used for testing
 packages:
   # repo: The URL for the upstream git repository


### PR DESCRIPTION
CLOUDBLD-3149

Signed-off-by: Sumin Cho <sucho@redhat.com>

The server side configuration, `cachito_gomod_strict_vendor`, ensures that the vendored dependencies are explicitly declared in **container.yaml**.

Currently, this configuration is set to `False`. However, if this configuration is set to `True`, the following behavior occurs:
> For a repo that has gomod dependencies, if the vendor directory exists and this config option is set to True, Cachito will fail the request.

If the configuration remains as `False`, we are at risk of reporting incorrect dependencies to Product Security.

On a side note, however, it seems that we have a history of committing this change and reverting it. Take a look at these following commits:

1. https://github.com/containerbuildsystem/cachito/commit/818ec8a4810b0e12879380c96bb90d2f62cc633e
2. https://github.com/containerbuildsystem/cachito/commit/ec1b9d7a88c8b4876a485bf5cae8c42d3e77f047#diff-3c3ad146779042216825b06cff08c9e3187e8eb77671a0d787edc4943c32daf2
3. https://github.com/containerbuildsystem/cachito/commit/d2efb965fd423888509df8103034120a6fdb94ad

Anyhow, if we want to set this configuration to `True`, we also should set the `strict_mode_enabled` configuration to `true` in **test_env_vars.yaml** as well. Otherwise, the integration test, `test_gomod_vendor_without_flag`, does not pass.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
