### PR TITLE
Configure Rubygems repositories for final usage

### DIFF
--- a/cachito/workers/nexus_scripts/rubygems_after_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/rubygems_after_content_staged.groovy
@@ -1,0 +1,93 @@
+/*
+This script configures Nexus so that a temporary user for the request is created and is given
+permission to access the Rubygems hosted repository and the raw hosted repository. It'd be
+preferable to give access to the Nexus anonymous user instead, but there is no way to add a role to
+a user.  You can only set the entire set of roles at once. This is an issue since if more than one
+Cachito request is in progress and modifies the set of roles at the same time, one of the additions
+will be lost.
+
+Differently from its JS counterpart, this script does not block outbound connections for the
+temporary request repositories. This is not needed because both Rubygems repositories used here
+are hosted repositories, and not rubygems.org proxies. In other words, they would not automatically
+pull unavailable contents from rubygems.org, as the npm repository would.
+ */
+import com.google.common.collect.Sets
+import groovy.json.JsonSlurper
+import groovy.transform.Field
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.sonatype.nexus.security.role.NoSuchRoleException
+import org.sonatype.nexus.security.user.UserStatus
+import org.sonatype.nexus.security.authz.AuthorizationManager
+import org.sonatype.nexus.security.role.Role
+import static org.sonatype.nexus.security.user.UserManager.DEFAULT_SOURCE
+import org.sonatype.nexus.security.user.UserNotFoundException
+
+
+// Scope logger to the script using @Field
+@Field final Logger logger = LoggerFactory.getLogger('cachito');
+
+
+void createUser(String username, String password, List<String> roles) {
+    try {
+        // security is an object that is injected by Nexus when the script is executed
+        def user = security.securitySystem.getUser(username)
+        logger.info("Modifying the existing user ${username}")
+        user.setFirstName(username)
+        user.setLastName(username)
+        user.setEmailAddress('noreply@domain.local')
+        user.setStatus(UserStatus.active)
+        security.securitySystem.updateUser(user)
+        security.setUserRoles(username, roles)
+        security.securitySystem.changePassword(username, password)
+    } catch (UserNotFoundException e) {
+        logger.info("Creating the user ${username}")
+        String firstName = username
+        String lastName = username
+        String email = 'noreply@domain.local'
+        Boolean active = true
+        // security is an object that is injected by Nexus when the script is executed
+        security.addUser(username, firstName, lastName, email, active, password, roles)
+    }
+}
+
+
+void createRole(String name, String description, List<String> privileges) {
+    // security is an object that is injected by Nexus when the script is executed
+    AuthorizationManager authorizationManager = security.securitySystem.getAuthorizationManager(DEFAULT_SOURCE)
+
+    String roleID = name
+    try {
+        Role role = authorizationManager.getRole(roleID)
+        logger.info("Modifying the role ${name}")
+        role.privileges = Sets.newHashSet(privileges)
+        authorizationManager.updateRole(role)
+    } catch (NoSuchRoleException e) {
+        logger.info("Creating the role ${name}")
+        List<String> roles = []
+        security.addRole(roleID, name, description, privileges, roles)
+    }
+}
+
+
+// Main execution starts here
+request = new JsonSlurper().parseText(args)
+['rubygems_repository_name', 'raw_repository_name', 'password', 'username'].each { param ->
+    assert request.get(param): "The ${param} parameter is required"
+}
+
+// Just name the role the same as the username for convenience
+String roleName = request.username
+// toString is needed to convert the GString to the Java String
+String rubygemsHostedPrivilege = "nx-repository-view-rubygems-${request.rubygems_repository_name}-read".toString()
+String rawHostedPrivilege = "nx-repository-view-raw-${request.raw_repository_name}-read".toString()
+List<String> privileges = [rubygemsHostedPrivilege, rawHostedPrivilege]
+// Create a role that has read access on the new repositories.
+// This will allow a user with this role to utilize the the Rubygems repos for this Cachito request.
+String desc = "Read access for ${request.rubygems_repository_name} and ${request.raw_repository_name}".toString()
+createRole(roleName, desc, privileges)
+List<String> roles = [roleName]
+// Create a user with the role above
+createUser(request.username, request.password, roles)
+
+return 'The repositories, user, and role were configured successfully'

--- a/cachito/workers/nexus_scripts/rubygems_before_content_staged.groovy
+++ b/cachito/workers/nexus_scripts/rubygems_before_content_staged.groovy
@@ -22,7 +22,7 @@ import org.sonatype.nexus.repository.config.WritePolicy
 def createHostedRepo(String name, String repoType) {
     WritePolicy writePolicy = WritePolicy.ALLOW_ONCE
     Boolean strictContentValidation = true
-    String blobStoreName = "cachito-ruby"
+    String blobStoreName = "cachito-rubygems"
     // repository is an object that is injected by Nexus when the script is executed
     if(repository.repositoryManager.exists(name)) {
         logger.info("Modifying the hosted repository ${name}")

--- a/docker/configure-nexus.groovy
+++ b/docker/configure-nexus.groovy
@@ -5,13 +5,13 @@ As part of the script, the following occurs:
 - Anonymous access is disabled
 - The "cachito-js" blob store is created
 - The "cachito-pip" blob store is created
-- The "cachito-ruby" blob store is created
+- The "cachito-rubygems" blob store is created
 - The "cachito-js-hosted" NPM hosted repository is created
 - The "cachito-js-proxy" NPM proxy repository is created
 - The "cachito-pip-raw" raw hosted repository is created
 - The "cachito-pip-proxy" PyPI proxy repository is created
-- The "cachito-ruby-raw" raw hosted repository is created
-- The "cachito-ruby-proxy" Rubygems proxy repository is created
+- The "cachito-rubygems-raw" raw hosted repository is created
+- The "cachito-rubygems-proxy" Rubygems proxy repository is created
 - The "cachito-js" NPM group repository is created which points to the "cachito-js-hosted" and "cachito-js-proxy" repositories
 - The "cachito" service account is created, which is used to manage the per-request proxy repositories, roles, and users
 - The "cachito_unprivileged" service account is created, which is used by the per-request proxy repositories to connect to the "cachito-js" repository
@@ -310,14 +310,14 @@ String pipRegistry = 'https://pypi.org/'
 String pipProxyType = 'pypi-proxy'
 createProxyRepo(pipProxyRepoName, pipProxyType, pipRegistry, pipBlobStoreName)
 
-String rubygemsBlobStoreName = 'cachito-ruby'
+String rubygemsBlobStoreName = 'cachito-rubygems'
 createBlobStore(rubygemsBlobStoreName)
 
-String rubygemsHostedRepoName = 'cachito-ruby-raw'
+String rubygemsHostedRepoName = 'cachito-rubygems-raw'
 String rubygemsHostedType = 'raw'
 createHostedRepo(rubygemsHostedRepoName, rubygemsHostedType, rubygemsBlobStoreName)
 
-String rubygemsProxyRepoName = 'cachito-ruby-proxy'
+String rubygemsProxyRepoName = 'cachito-rubygems-proxy'
 String rubygemsRegistry = 'https://rubygems.org/'
 String rubygemsProxyType = 'rubygems-proxy'
 createProxyRepo(rubygemsProxyRepoName, rubygemsProxyType, rubygemsRegistry, rubygemsBlobStoreName)

--- a/tests/test_workers/test_nexus.py
+++ b/tests/test_workers/test_nexus.py
@@ -272,6 +272,7 @@ def test_create_or_update_scripts(mock_cous):
         "pip_before_content_staged",
         "pip_cleanup",
         "rubygems_before_content_staged",
+        "rubygems_after_content_staged",
     }
     for call_args in mock_cous.call_args_list:
         script_name = call_args[0][0]


### PR DESCRIPTION
SPMM-9899

This is basically a copy-paste of [this](https://github.com/containerbuildsystem/cachito/pull/237), but I just couldn't think of any good way to refactor it. Also note that I changed names of blob store and repositories from `ruby` to `rubygems` to match the naming conventions of the rest of the code, so you'll probably have to rebuild your environment to make it work.

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
