### PR TITLE
RubyGems: Generate config file for Bundler

### DIFF
--- a/cachito/workers/tasks/rubygems.py
+++ b/cachito/workers/tasks/rubygems.py
@@ -1,9 +1,16 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from os.path import relpath
+from pathlib import Path
+from textwrap import dedent
+
+from cachito.errors import CachitoError
 from cachito.workers import nexus
 from cachito.workers.pkg_managers.rubygems import (
     get_rubygems_hosted_repo_name,
     get_rubygems_nexus_username,
 )
 from cachito.workers.tasks.celery import app
+from cachito.workers.tasks.utils import make_base64_config_file
 
 __all__ = ["cleanup_rubygems_request"]
 
@@ -16,3 +23,61 @@ def cleanup_rubygems_request(request_id):
         "username": get_rubygems_nexus_username(request_id),
     }
     nexus.execute_script("rubygems_cleanup", payload)
+
+
+def _get_config_file_for_given_package(
+    dependencies, bundle_dir, package_source_dir, rubygems_hosted_url
+):
+    """
+    Get Bundler config file.
+
+    Returns a Bundler config file with a mirror set for RubyGems dependencies pointing to
+    `rubygems_hosted_repo` URL. All GIT dependencies are configured to be replaced by local git
+     repos.
+
+    :param dependencies: an array of dependencies (dictionaries) with keys
+        "name": package name,
+        "path": an absolute path to a locally downloaded git repo,
+        "kind": dependency kind
+    :param bundle_dir: an absolute path to the root of the Cachito bundle
+    :param package_source_dir: a path to the root directory of given package
+    :param rubygems_hosted_url: URL pointing to a request specific RubyGems hosted repo with
+     hardcoded user credentials
+    :return: dict with "content", "path" and "type" keys
+    """
+    base_config = dedent(
+        f"""
+        # Sets mirror for all RubyGems sources
+        BUNDLE_MIRROR__ALL: "{rubygems_hosted_url}"
+        # Turn off the probing
+        BUNDLE_MIRROR__ALL__FALLBACK_TIMEOUT: "false"
+        # Install only ruby platform gems (=> gems with native extensions are compiled from source).
+        # All gems should be platform independent already, so why not keep it here.
+        BUNDLE_FORCE_RUBY_PLATFORM: "true"
+        BUNDLE_DEPLOYMENT: "true"
+        # Defaults to true when deployment is set to true
+        BUNDLE_FROZEN: "true"
+        # For local Git replacements, branches don't have to be specified (commit hash is enough)
+        BUNDLE_DISABLE_LOCAL_BRANCH_CHECK: "true"
+    """
+    )
+
+    config = [base_config]
+    for dependency in dependencies:
+        if dependency["kind"] == "GIT":
+            # These substitutions are required by Bundler
+            name = dependency["name"].upper().replace("-", "___").replace(".", "__")
+            relative_path = relpath(dependency["path"], package_source_dir)
+            dep_replacement = f'BUNDLE_LOCAL__{name}: "{relative_path + "/app"}"'
+            config.append(dep_replacement)
+
+    final_config = "\n".join(config)
+
+    config_file_path = package_source_dir / Path(".bundle/config")
+    if config_file_path.exists():
+        raise CachitoError(
+            f"Cachito wants to create a config file at location {config_file_path}, "
+            f"but it already exists."
+        )
+    final_path = config_file_path.relative_to(Path(bundle_dir))
+    return make_base64_config_file(final_config, final_path)

--- a/tests/test_workers/test_tasks/test_rubygems.py
+++ b/tests/test_workers/test_tasks/test_rubygems.py
@@ -1,5 +1,11 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import base64
+from pathlib import Path
 from unittest import mock
 
+import pytest
+
+from cachito.errors import CachitoError
 from cachito.workers.tasks import rubygems
 
 
@@ -12,3 +18,55 @@ def test_cleanup_rubygems_request(mock_exec_script):
         "username": "cachito-rubygems-42",
     }
     mock_exec_script.assert_called_once_with("rubygems_cleanup", expected_payload)
+
+
+class MockBundleDir(type(Path())):
+    """Mocked RequestBundleDir."""
+
+    def __new__(cls, *args, **kwargs):
+        """Make a new MockBundleDir."""
+        self = super().__new__(cls, *args, **kwargs)
+        self.source_root_dir = self.joinpath("app")
+        self.rubygems_deps_dir = self / "deps" / "rubygems"
+        return self
+
+
+@pytest.mark.parametrize("exists", [True, False])
+def test_get_config_file(tmp_path, exists):
+    bundle_dir = MockBundleDir(tmp_path)
+
+    pkg_and_deps_info = {
+        "dependencies": [
+            {
+                "name": "rspec-core.3",
+                "path": bundle_dir.rubygems_deps_dir / "rspec-core.3" / "some-path",
+                "kind": "GIT",
+            }
+        ],
+    }
+    rubygems_hosted_repo = "https://admin:admin@hosted.com"
+    package_root = bundle_dir.source_root_dir / "pkg1"
+
+    if exists:
+        config_file = package_root / Path(".bundle/config")
+        config_file.parent.mkdir(parents=True)
+        config_file.touch()
+        msg = (
+            f"Cachito wants to create a config file at location {config_file}, "
+            f"but it already exists."
+        )
+        with pytest.raises(CachitoError, match=msg):
+            rubygems._get_config_file_for_given_package(
+                pkg_and_deps_info["dependencies"], bundle_dir, package_root, rubygems_hosted_repo
+            )
+    else:
+        dep = rubygems._get_config_file_for_given_package(
+            pkg_and_deps_info["dependencies"], bundle_dir, package_root, rubygems_hosted_repo
+        )
+
+        assert dep["path"] == "app/pkg1/.bundle/config"
+        assert dep["type"] == "base64"
+        contents = base64.b64decode(dep["content"]).decode()
+        assert f'BUNDLE_MIRROR__ALL: "{rubygems_hosted_repo}"' in contents
+        git_dep = 'BUNDLE_LOCAL__RSPEC___CORE__3: "../../deps/rubygems/rspec-core.3/some-path/app"'
+        assert git_dep in contents


### PR DESCRIPTION
SPMM-9901

In order to redirect Bundler to use dependencies cached by Cachito, a
configuration file will be provided.

While there already may be a `.bundle/config` file in the repository for
which dependencies were requested, it's not the case for any of the
products that we indent to support and therefore an exception is raised.

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
