### PR TITLE
Add integration test for request without package manager

### DIFF
--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -1829,3 +1829,22 @@ symlink_loop:
     deps/gomod/pkg/mod/cache/download: null
   content_manifest:
   - purl: "pkg:golang/github.com%2Fcachito-testing%2Fcachito-gomod-symlink-loop@v0.0.0-20220712180726-2448c37cc276"
+# gomod package without package manager and dependencies
+# repo: The URL for the upstream git repository
+# ref: A git reference at the given git repository
+# flags: A list of strings with Cachito flags
+# expected_files: Expected source files <relative_path>: <file_URL>
+# expected_deps_files: Expected dependencies files (empty)
+# response_expectations: Parts of the Cachito response to check
+# content_manifest: PURLs for image contents part
+without_pkg_manager:
+  repo: https://github.com/cachito-testing/cachito-gomod-without-deps.git
+  ref: a888f7261b9a9683972fbd77da2d12fe86faef5e
+  pkg_managers: []
+  response_expectations:
+    packages: []
+    dependencies: []
+  expected_files:
+    app: https://github.com/cachito-testing/cachito-gomod-without-deps/tarball/a888f7261b9a9683972fbd77da2d12fe86faef5e
+    deps: null
+  content_manifest: []

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -31,6 +31,7 @@ from . import utils
         ("gomod_packages", "force_tidy_without_deps"),
         ("gomod_packages", "force_tidy_vendored"),
         ("gomod_packages", "symlink_loop"),
+        ("gomod_packages", "without_pkg_manager"),
         ("gomod_vendor_check", "correct_vendor"),
         ("gomod_vendor_check", "no_vendor"),
         ("npm_packages", "without_deps"),


### PR DESCRIPTION
[CLOUDBLD-4503](https://projects.engineering.redhat.com/browse/CLOUDBLD-4503)

Signed-off-by: Sumin Cho <sucho@redhat.com>
# M1. Without Package Manager
The application repository has contents, any text file, source code, etc.
## Request Parameters
```
repo: <repo>
ref: <ref>
pkg_managers: []
```
## Verification
- [X] The request completes successfully.
- [X] Both “.dependencies” and “.packages” are empty.
- [X] The source tarball includes the application source code under the app directory.
- [X] The source tarball does not include the deps directory.
- [X] The content manifest is successfully generated and contains correct content, which is an empty manifest.
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
