### PR TITLE
Skip RubyGems without specified version

### DIFF
--- a/tests/test_workers/test_pkg_managers/test_rubygems.py
+++ b/tests/test_workers/test_pkg_managers/test_rubygems.py
@@ -111,6 +111,24 @@ class TestGemlockParsing:
                     GemMetadata("builder", "3.2.4", "GEM", "https://rubygems.org/"),
                 ],
             ),
+            # GEM dependencies without specified version should be skipped
+            (
+                dedent(
+                    """
+                    GEM
+                      remote: https://rubygems.org/
+                      specs:
+                        zeitwerk
+
+                    PLATFORMS
+                      ruby
+
+                    DEPENDENCIES
+                      zeitwerk
+                    """
+                ),
+                [],
+            ),
         ),
     )
     def test_parsing_of_valid_cases(self, file_contents, expected_dependencies, tmpdir):
@@ -255,23 +273,6 @@ class TestGemlockParsing:
                     """
                 ),
                 "Gemfile.lock contains unsupported dependency type.",
-            ),
-            (
-                dedent(
-                    """
-                    GEM
-                      remote: https://rubygems.org/
-                      specs:
-                        zeitwerk
-
-                    PLATFORMS
-                      ruby
-
-                    DEPENDENCIES
-                      zeitwerk
-                    """
-                ),
-                "Unspecified name or version of a RubyGem.",
             ),
             (
                 dedent(


### PR DESCRIPTION
Some Ruby projects ([e.g. zync](https://github.com/3scale/zync/blob/235a889a4bf49bb7eab834688b471014d2a59f84/Gemfile#L74)) define dependencies only for a given platform using `platforms:` keyword. Such dependencies [are installed only if](https://bundler.io/v2.3/man/gemfile.5.html#PLATFORMS) the specified platform matches the target platform. If not, these dependencies are still included in the `Gemfile.lock`, but without a version. Therefore, if Cachito encounters a dependency without a version in a `Gemfile.lock` of a project, this dependency will be skipped.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
