### PR TITLE
Update 'PYTHON_VERSION_VENV' to 3.10 and add python3.10 to tox configs

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.8]
+        python-version: ["3.10", "3.9"]
 
     steps:
     - uses: actions/checkout@v1
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -129,7 +129,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CACHITO_COMPOSE_ENGINE ?= docker-compose
-PYTHON_VERSION_VENV ?= python3.9
-TOX_ENVLIST ?= py39
+PYTHON_VERSION_VENV ?= python3.10
+TOX_ENVLIST ?= python3.10
 TOX_ARGS ?=
 
 PODMAN_COMPOSE_AUTO_URL ?= https://raw.githubusercontent.com/containers/podman-compose/devel/podman_compose.py

--- a/cachito/web/migrations/env.py
+++ b/cachito/web/migrations/env.py
@@ -46,7 +46,9 @@ def run_migrations_offline():
     """
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
-        url=url, target_metadata=target_metadata, literal_binds=True,
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
     )
 
     with context.begin_transaction():

--- a/cachito/web/migrations/versions/92f0d370ba4d_add_requesterror_table.py
+++ b/cachito/web/migrations/versions/92f0d370ba4d_add_requesterror_table.py
@@ -24,7 +24,10 @@ def upgrade():
         sa.Column("error_type", sa.String(), nullable=False),
         sa.Column("message", sa.String(), nullable=False),
         sa.Column("occurred", sa.DateTime(), nullable=True),
-        sa.ForeignKeyConstraint(["request_id"], ["request.id"],),
+        sa.ForeignKeyConstraint(
+            ["request_id"],
+            ["request.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("id"),
         sa.UniqueConstraint("request_id"),

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -723,7 +723,8 @@ class RequestState(db.Model):
                 cls.state_reason,
                 cls.updated,
                 func.extract(
-                    "epoch", cls.updated.cast(TIMESTAMP) - states.c.updated.cast(TIMESTAMP),
+                    "epoch",
+                    cls.updated.cast(TIMESTAMP) - states.c.updated.cast(TIMESTAMP),
                 ).label("duration"),
                 func.extract(
                     "epoch",

--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -319,7 +319,10 @@ def resolve_npm(app_source_path, request, skip_deps=None):
     bundle_dir = RequestBundleDir(request["id"])
     bundle_dir.npm_deps_dir.mkdir(exist_ok=True)
     package_and_deps_info["downloaded_deps"] = download_dependencies(
-        bundle_dir.npm_deps_dir, package_and_deps_info["deps"], proxy_repo_url, skip_deps,
+        bundle_dir.npm_deps_dir,
+        package_and_deps_info["deps"],
+        proxy_repo_url,
+        skip_deps,
     )
 
     # Remove all the "bundled" keys since that is an implementation detail that should not be

--- a/cachito/workers/tasks/npm.py
+++ b/cachito/workers/tasks/npm.py
@@ -191,7 +191,10 @@ def fetch_npm_source(request_id, package_configs=None):
 
 
 def generate_npmrc_config_files(
-    proxy_repo_url: str, username: str, password: str, subpaths: List[str],
+    proxy_repo_url: str,
+    username: str,
+    password: str,
+    subpaths: List[str],
 ) -> List[dict]:
     """
     Generate one .npmrc config file for each subpath in request.

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -76,7 +76,9 @@ def fetch_pip_source(request_id, package_configs=None):
         pkg_path = pkg_cfg.get("path", ".")
         source_dir = bundle_dir.app_subpath(pkg_path).source_dir
         set_request_state(
-            request_id, "in_progress", f"Fetching dependencies at the {pkg_path!r} directory",
+            request_id,
+            "in_progress",
+            f"Fetching dependencies at the {pkg_path!r} directory",
         )
         request = get_request(request_id)
         pkg_and_deps_info = resolve_pip(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ['py38']  # as soon as black > 20.8b1 is released and we start using it, we can include py39 here
+target-version = ['py39']
 
 # Leave this empty to avoid a bug introduced in setuptools-git-versioning 1.8.0
 # See https://github.com/dolfinus/setuptools-git-versioning/blob/df461e6b33493642ef39b96f8c5d68689f304bf7/setuptools_git_versioning.py#L180

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,11 @@ setup(
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     license="GPLv3+",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     setup_requires=['setuptools-git-versioning'],
     version_config={
         "dev_template": "{tag}.post{ccount}-git.{sha}",

--- a/tests/integration/test_request_metrics.py
+++ b/tests/integration/test_request_metrics.py
@@ -39,7 +39,8 @@ def test_get_request_metrics_summary(api_client):
         api_client.wait_for_complete_request(request)
 
     resp = api_client.fetch_request_metrics_summary(
-        finished_from=finished_from, finished_to=datetime.utcnow().isoformat(),
+        finished_from=finished_from,
+        finished_to=datetime.utcnow().isoformat(),
     )
     assert resp.status_code == 200
     summary = resp.json()
@@ -63,7 +64,8 @@ def test_get_request_metrics_summary(api_client):
 
     # Check empty datetime range
     resp = api_client.fetch_request_metrics_summary(
-        finished_from=finished_from, finished_to=finished_from,
+        finished_from=finished_from,
+        finished_to=finished_from,
     )
     assert resp.status_code == 200
     summary = resp.json()

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -72,7 +72,9 @@ class TestCachedPackage:
             commit = repo.head.commit.hexsha
 
             client = utils.Client(
-                test_env["api_url"], test_env["api_auth_type"], test_env.get("timeout"),
+                test_env["api_url"],
+                test_env["api_auth_type"],
+                test_env.get("timeout"),
             )
             response = client.create_new_request(
                 payload={

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -143,7 +143,8 @@ class Client:
 
     def fetch_request_metrics_summary(self, **params) -> requests.Response:
         resp = self.requests_session.get(
-            f"{self._cachito_api_url}/request-metrics/summary", params=params,
+            f"{self._cachito_api_url}/request-metrics/summary",
+            params=params,
         )
         resp.raise_for_status()
         return resp

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -96,8 +96,20 @@ def test_request_invalid_params(invalid_param):
 @pytest.mark.parametrize(
     "dependency_replacements, pkg_managers, user, expected_pkg_managers, flags",
     (
-        ([], [], None, [], None,),
-        ([], ["gomod", "git-submodule"], None, ["gomod", "git-submodule"], None,),
+        (
+            [],
+            [],
+            None,
+            [],
+            None,
+        ),
+        (
+            [],
+            ["gomod", "git-submodule"],
+            None,
+            ["gomod", "git-submodule"],
+            None,
+        ),
         (
             [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}],
             ["gomod"],
@@ -119,10 +131,34 @@ def test_request_invalid_params(invalid_param):
             ["gomod", "git-submodule"],
             None,
         ),
-        ([], [], "tom_hanks@DOMAIN.LOCAL", [], None,),
-        ([], ["npm"], None, ["npm"], None,),
-        ([], ["pip"], None, ["pip"], None,),
-        ([], ["yarn"], None, ["yarn"], None,),
+        (
+            [],
+            [],
+            "tom_hanks@DOMAIN.LOCAL",
+            [],
+            None,
+        ),
+        (
+            [],
+            ["npm"],
+            None,
+            ["npm"],
+            None,
+        ),
+        (
+            [],
+            ["pip"],
+            None,
+            ["pip"],
+            None,
+        ),
+        (
+            [],
+            ["yarn"],
+            None,
+            ["yarn"],
+            None,
+        ),
     ),
 )
 @mock.patch("cachito.web.api_v1.chain")
@@ -214,7 +250,11 @@ def test_create_and_fetch_request(
 
 @mock.patch("cachito.web.api_v1.chain")
 def test_create_request_with_gomod_package_configs(
-    mock_chain, app, auth_env, client, db,
+    mock_chain,
+    app,
+    auth_env,
+    client,
+    db,
 ):
     package_value = {"gomod": [{"path": "."}, {"path": "proxy"}]}
     data = {
@@ -245,7 +285,11 @@ def test_create_request_with_gomod_package_configs(
 
 @mock.patch("cachito.web.api_v1.chain")
 def test_create_request_with_npm_package_configs(
-    mock_chain, app, auth_env, client, db,
+    mock_chain,
+    app,
+    auth_env,
+    client,
+    db,
 ):
     package_value = {"npm": [{"path": "client"}, {"path": "proxy"}]}
     data = {
@@ -317,7 +361,11 @@ def test_create_request_with_pip_package_configs(mock_chain, app, auth_env, clie
 
 @mock.patch("cachito.web.api_v1.chain")
 def test_create_request_with_yarn_package_configs(
-    mock_chain, app, auth_env, client, db,
+    mock_chain,
+    app,
+    auth_env,
+    client,
+    db,
 ):
     package_value = {"yarn": [{"path": "client"}, {"path": "proxy"}]}
     data = {
@@ -1251,7 +1299,14 @@ def test_set_state(state, app, client, db, worker_auth_env, tmpdir):
 @pytest.mark.parametrize("pkg_managers", (["gomod"], ["npm"], ["gomod", "npm"]))
 @mock.patch("cachito.web.api_v1.tasks.cleanup_npm_request")
 def test_set_state_stale(
-    mock_cleanup_npm, pkg_managers, bundle_exists, app, client, db, worker_auth_env, tmpdir,
+    mock_cleanup_npm,
+    pkg_managers,
+    bundle_exists,
+    app,
+    client,
+    db,
+    worker_auth_env,
+    tmpdir,
 ):
     data = {
         "repo": "https://github.com/release-engineering/project.git",
@@ -2451,7 +2506,8 @@ def test_fetch_request_packages_and_dependencies(
 
     if packages is not None:
         _write_test_packages_data(
-            packages, RequestBundleDir(request.id, root=cachito_bundles_dir).packages_data,
+            packages,
+            RequestBundleDir(request.id, root=cachito_bundles_dir).packages_data,
         )
 
     rv = client.get(f"/api/v1/requests/{request.id}")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,8 @@ from cachito.web.models import PackageManager, Request, RequestStateMapping
 
 
 @pytest.mark.parametrize(
-    "name,expected", [["gomod", "gomod"], ["", None], [None, None], ["unknown", None]],
+    "name,expected",
+    [["gomod", "gomod"], ["", None], [None, None], ["unknown", None]],
 )
 def test_package_manager_get_by_name(name, expected, app, db, auth_env):
     pkg_manager: Optional[PackageManager] = PackageManager.get_by_name(name)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -128,7 +128,8 @@ def test_rabbitmq_ok(mock_kombu_connection, error, expect_reason):
 
 
 @pytest.mark.parametrize(
-    "num_retries, sleep_intervals", [(0, []), (1, [0.25]), (5, [0.25, 0.5, 1.0, 2.0, 4.0])],
+    "num_retries, sleep_intervals",
+    [(0, []), (1, [0.25]), (5, [0.25, 0.5, 1.0, 2.0, 4.0])],
 )
 @mock.patch.object(status.app.control, "inspect")
 @mock.patch("time.sleep")

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -120,7 +120,11 @@ def test_validate_celery_config_failure_default_env_vars(mock_isdir, default_env
 
 
 @pytest.mark.parametrize(
-    "hoster_username, hoster_password", ((None, "password"), ("username", None),)
+    "hoster_username, hoster_password",
+    (
+        (None, "password"),
+        ("username", None),
+    ),
 )
 @patch("os.path.isdir", return_value=True)
 def test_validate_celery_config_invalid_nexus_hoster_config(
@@ -163,7 +167,8 @@ def test_validate_celery_config_missing_cert(mock_isdir, auth_type, has_cert, au
 
 
 @pytest.mark.parametrize(
-    "missing_config", ("cachito_nexus_password", "cachito_nexus_url", "cachito_nexus_username"),
+    "missing_config",
+    ("cachito_nexus_password", "cachito_nexus_url", "cachito_nexus_username"),
 )
 @patch("cachito.workers.config.get_worker_config")
 def test_validate_nexus_config(mock_gwc, missing_config):

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -167,7 +167,13 @@ def test_download_dependencies(
 @mock.patch("shutil.move")
 @mock.patch("cachito.workers.paths.get_worker_config")
 def test_download_dependencies_skip_deps(
-    mock_gwc, mock_move, mock_run_cmd, mock_gawnf, mock_exists, mock_td, tmpdir,
+    mock_gwc,
+    mock_move,
+    mock_run_cmd,
+    mock_gawnf,
+    mock_exists,
+    mock_td,
+    tmpdir,
 ):
     bundles_dir = tmpdir.mkdir("bundles")
     mock_gwc.return_value.cachito_bundles_dir = str(bundles_dir)

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -419,7 +419,13 @@ def test_resolve_gomod_vendor_dependencies(
 @mock.patch("pathlib.Path.is_dir")
 @pytest.mark.parametrize("strict_vendor", [True, False])
 def test_resolve_gomod_strict_mode_raise_error(
-    mock_isdir, mock_gwc, mock_golang_version, mock_run, mock_temp_dir, tmpdir, strict_vendor,
+    mock_isdir,
+    mock_gwc,
+    mock_golang_version,
+    mock_run,
+    mock_temp_dir,
+    tmpdir,
+    strict_vendor,
 ):
     mock_isdir.return_value = True
     # Mock the get_worker_config
@@ -1419,7 +1425,7 @@ def test_run_download_cmd_success(mock_sleep, mock_run, mock_worker_config, trie
     assert mock_sleep.call_count == tries_needed - 1
 
     for n in range(tries_needed - 1):
-        wait = 2 ** n
+        wait = 2**n
         assert f"Backing off run_go(...) for {wait:.1f}s" in caplog.text
 
 

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -345,7 +345,12 @@ def test_get_deps_allowlisted_file_dep():
     "package_lock_deps,workspaces,replacement,result",
     [
         ({}, [], set(), {}),
-        ({"a": {"version": "file:a"}}, ["a"], set(), {},),
+        (
+            {"a": {"version": "file:a"}},
+            ["a"],
+            set(),
+            {},
+        ),
         (
             {
                 "a": {"version": "file:a"},

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -1736,7 +1736,11 @@ class TestPipRequirementsFile:
                 [],
             ),
             # Global options
-            ("--only-binary :all:", [], ["--only-binary", ":all:"],),
+            (
+                "--only-binary :all:",
+                [],
+                ["--only-binary", ":all:"],
+            ),
             # Global options with a requirement
             (
                 "aiowsgi==0.7 --only-binary :all:",
@@ -2118,7 +2122,12 @@ class TestPipRequirementsFile:
                 },
             ),
             # Editable option, "--e", is not dropped when url is not set
-            ("git+https://github.com/monty/spam/archive/58c88.tar.gz#egg=spam", ["-e"], {}, {},),
+            (
+                "git+https://github.com/monty/spam/archive/58c88.tar.gz#egg=spam",
+                ["-e"],
+                {},
+                {},
+            ),
             # Editable option, "--editable", is dropped when setting url
             (
                 "git+https://github.com/monty/spam/archive/58c88.tar.gz#egg=spam",
@@ -2170,7 +2179,12 @@ class TestPipRequirementsFile:
                 },
             ),
             # Extras are NOT cleared when a new URL is not set
-            ("spam[SALTY]", [], {}, {},),
+            (
+                "spam[SALTY]",
+                [],
+                {},
+                {},
+            ),
             # Version specs are cleared when setting a new URL
             (
                 "spam==1.2.3",
@@ -2184,7 +2198,12 @@ class TestPipRequirementsFile:
                 },
             ),
             # Version specs are NOT cleared when a new URL is not set
-            ("spam==1.2.3", [], {}, {},),
+            (
+                "spam==1.2.3",
+                [],
+                {},
+                {},
+            ),
             # Qualifiers persists
             (
                 "https://github.com/monty/spam/archive/58c88.tar.gz#egg=spam&spam=maps",
@@ -2201,7 +2220,11 @@ class TestPipRequirementsFile:
         ),
     )
     def test_pip_requirement_copy(
-        self, requirement_line, requirement_options, new_values, expected_changes,
+        self,
+        requirement_line,
+        requirement_options,
+        new_values,
+        expected_changes,
     ):
         """Test PipRequirement.copy method."""
         original_requirement = pip.PipRequirement.from_line(requirement_line, requirement_options)
@@ -3017,7 +3040,8 @@ class TestDownload:
             options.append(host)
 
         req_file = self.mock_requirements_file(
-            requirements=[pypi_req, vcs_req, url_req], options=options,
+            requirements=[pypi_req, vcs_req, url_req],
+            options=options,
         )
 
         proxy_url = "https://pypi-proxy.example.org"
@@ -3031,7 +3055,10 @@ class TestDownload:
 
         pypi_download = pip_deps / "foo" / "foo-1.0.tar.gz"
         vcs_download = pip_deps.joinpath(
-            "github.com", "spam", "eggs", f"eggs-external-gitcommit-{GIT_REF}.tar.gz",
+            "github.com",
+            "spam",
+            "eggs",
+            f"eggs-external-gitcommit-{GIT_REF}.tar.gz",
         )
         url_download = pip_deps / "external-bar" / "bar-external-sha256-654321.tar.gz"
 
@@ -3295,7 +3322,9 @@ def test_get_index_url_invalid_url():
     expected = "Nexus PyPI hosted repo URL: repository/cachito-pip-hosted-5/ is not a valid URL"
     with pytest.raises(ValidationError, match=expected):
         pip.get_index_url(
-            "repository/cachito-pip-hosted-5/", "admin", "admin123",
+            "repository/cachito-pip-hosted-5/",
+            "admin",
+            "admin123",
         )
 
 

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -112,7 +112,9 @@ def test_pick_strongest_crypto_hash(integrity_value, expected):
             "https://example.org/fecha.tar.gz#123456",
             {"version": "2.0.0"},
             JSDependency(
-                "fecha", source="https://example.org/fecha.tar.gz#123456", integrity=MOCK_INTEGRITY,
+                "fecha",
+                source="https://example.org/fecha.tar.gz#123456",
+                integrity=MOCK_INTEGRITY,
             ),
             ("123456", "sha1"),
         ),
@@ -439,7 +441,10 @@ def test_get_deps_disallowed_file_dep(mock_convert_hosted):
 @mock.patch("cachito.workers.pkg_managers.yarn.get_worker_config")
 @mock.patch("cachito.workers.pkg_managers.yarn._get_deps")
 def test_get_package_and_deps(
-    mock_get_deps, mock_get_config, mock_lockfile_fromfile, tmp_path,
+    mock_get_deps,
+    mock_get_config,
+    mock_lockfile_fromfile,
+    tmp_path,
 ):
     packjson_path = tmp_path / "package-lock.json"
     packjson_path.write_text('{"name": "foo", "version": "1.0.0"}')

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -347,7 +347,9 @@ def test_finalize_request(
 @mock.patch("cachito.workers.tasks.general.get_request_packages_and_dependencies")
 @mock.patch("cachito.workers.tasks.general.set_request_state")
 def test_finalize_request_with_error_when_fetching_api(
-    mock_set_state, mock_get_request_packages_and_dependencies, task_passes_state_check,
+    mock_set_state,
+    mock_get_request_packages_and_dependencies,
+    task_passes_state_check,
 ):
     request_id = 42
     error_message = f"Packages file could not be loaded for request {request_id}"

--- a/tests/test_workers/test_tasks/test_pip.py
+++ b/tests/test_workers/test_tasks/test_pip.py
@@ -114,7 +114,8 @@ def test_fetch_pip_source(
 
     if cfg_contents:
         mock_update_cfg.assert_called_once_with(
-            request["id"], cfg_contents,
+            request["id"],
+            cfg_contents,
         )
 
     expected = pkg_data["package"].copy()

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -191,7 +191,11 @@ def test_set_packages_and_deps_counts(
             None,
             "connection error: connection failed",
         ),
-        (requests.Timeout("timed out"), None, "connection error: timed out",),
+        (
+            requests.Timeout("timed out"),
+            None,
+            "connection error: timed out",
+        ),
         (
             None,
             requests.HTTPError("404 Client Error: NOT FOUND"),
@@ -225,7 +229,8 @@ def test_get_request_or_fail(
         assert request == {"id": 42, "state": "complete"}
 
     mock_requests_get.assert_called_once_with(
-        "http://cachito.domain.local/api/v1/requests/42", timeout=60,
+        "http://cachito.domain.local/api/v1/requests/42",
+        timeout=60,
     )
 
 
@@ -238,7 +243,11 @@ def test_get_request_or_fail(
             None,
             "connection error: connection failed",
         ),
-        (requests.Timeout("timed out"), None, "connection error: timed out",),
+        (
+            requests.Timeout("timed out"),
+            None,
+            "connection error: timed out",
+        ),
         (
             None,
             requests.HTTPError("404 Client Error: NOT FOUND"),
@@ -273,7 +282,9 @@ def test_patch_request_or_fail(
         utils._patch_request_or_fail(42, payload, "connection error: {exc}", "status error: {exc}")
 
     mock_requests_patch.assert_called_once_with(
-        "http://cachito.domain.local/api/v1/requests/42", json=payload, timeout=60,
+        "http://cachito.domain.local/api/v1/requests/42",
+        json=payload,
+        timeout=60,
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = bandit,black,flake8,mypy,py38,py39
+envlist = bandit,black,flake8,mypy,python3.9,python3.10
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
+    3.9: python3.9
+    3.10: python3.10
 
 [testenv]
 deps =
@@ -30,14 +30,11 @@ commands_post =
     rm -rf {envtmpdir}/prometheus_metrics
 
 [testenv:black]
-# a bug in python3.9 is causing occasional failures: https://bugs.python.org/issue43498,
-# after this is fixed, basepython can be removed
-basepython = python3.8
 description = black checks [Mandatory]
 skip_install = true
 deps =
     # Pin the version of black and click to avoid a newer version causing tox to fail
-    black==19.10b0
+    black==22.6.0
     click==8.0.3
 commands =
     black --check --diff cachito tests


### PR DESCRIPTION
CLOUDBLD-3117

Signed-off-by: Sumin Cho <sucho@redhat.com>

Since Cachito services run on Python 3.10, the unit tests should also cover this version as well. 

Should we get rid of Python 3.8 from the unit tests now? Three runs of unit testing seems time-consuming.

Also, we will need to add Python 3.10 to GitHub Actions.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
