### PR TITLE
Pin git to version 2.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,13 +712,13 @@ Offline Installations   | ✓     | x   | x   | x    |
 ### Actual Tool Versions
 
 Tool   | Version |
----    | ---     |
+---    |---------|
 Go     | 1.17    |
 Npm    | 8.0.0   |
 Node   | 16.11.0 |
 Pip    | 21.2.3  |
 Python | 3.10.0  |
-Git    | 2.33.1  |
+Git    | 2.32.0  |
 Yarn*  | 1.x     |
 
 * Cachito does not use the Yarn runtime. The processing of yarn.lock files is handled by

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -8,7 +8,7 @@ RUN dnf -y install \
     --setopt=tsflags=nodocs \
     golang \
     gcc \
-    git-core \
+    git-core-2.32.0 \
     krb5-devel \
     libffi-devel \
     mercurial \


### PR DESCRIPTION
In git version 2.37.1 there is an owner check for top level directory
https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
This causes failures for git fetch cmd in Cachito.

Signed-off-by: ejegrova <ejegrova@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
