### PR TITLE
Remove version template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
     license="GPLv3+",
     python_requires=">=3.9",
     setup_requires=['setuptools-git-versioning'],
-    version_config={
-        "dev_template": "{tag}.post{ccount}-git.{sha}",
+    setuptools_git_versioning={
+        "enabled": True,
+        "dev_template": "{tag}.post{ccount}+git.{sha}",
     },
 )


### PR DESCRIPTION
We have invalid version specified, it does not comply with PEP 440.
Also 'version_config' option is depracated.

Signed-off-by: ejegrova <ejegrova@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
