### PR TITLE
Fix UploadError/NetworkError exception handling

### DIFF
--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -411,7 +411,7 @@ def upload_raw_component(repo_name, directory, components, to_nexus_hoster=True)
 
     try:
         upload_component(params, payload, to_nexus_hoster, additional_data)
-    except NetworkError:
+    except UploadError:
         log.exception("Failed to upload %r to the raw Nexus repository", components)
         raise
 

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -30,7 +30,7 @@ from cachito.errors import (
 )
 from cachito.workers import nexus
 from cachito.workers.config import get_worker_config
-from cachito.workers.errors import NexusScriptError
+from cachito.workers.errors import NexusScriptError, UploadError
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers import general
 from cachito.workers.pkg_managers.general import (
@@ -1965,7 +1965,7 @@ def _push_downloaded_requirement(requirement, pip_repo_name, raw_repo_name):
     if requirement["kind"] == "pypi":
         try:
             upload_pypi_package(pip_repo_name, requirement["path"])
-        except (NetworkError, ValueError):
+        except UploadError:
             if nexus.get_component_info_from_nexus(
                 pip_repo_name,
                 "pypi",
@@ -1987,7 +1987,7 @@ def _push_downloaded_requirement(requirement, pip_repo_name, raw_repo_name):
         dest_dir, filename = requirement["raw_component_name"].rsplit("/", 1)
         try:
             upload_raw_package(raw_repo_name, requirement["path"], dest_dir, filename, True)
-        except (NetworkError, ValueError):
+        except UploadError:
             if nexus.get_component_info_from_nexus(
                 raw_repo_name,
                 "raw",

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -18,7 +18,7 @@ from cachito.errors import (
     NexusError,
     ValidationError,
 )
-from cachito.workers.errors import NexusScriptError
+from cachito.workers.errors import NexusScriptError, UploadError
 from cachito.workers.pkg_managers import general, pip
 from tests.helper_utils import write_file_tree
 
@@ -3363,7 +3363,7 @@ def test_push_downloaded_requirement_from_pypi(mock_upload, dev):
 @mock.patch("cachito.workers.pkg_managers.pip.upload_pypi_package")
 @mock.patch("cachito.workers.pkg_managers.pip.nexus.get_component_info_from_nexus")
 def test_push_downloaded_requirement_from_pypi_duplicated(mock_get_info, mock_upload, uploaded):
-    mock_upload.side_effect = NetworkError("stub")
+    mock_upload.side_effect = UploadError("stub")
     mock_get_info.return_value = uploaded
     pip_repo_name = "test-pip-hosted"
     raw_repo_name = "test-pip-raw"
@@ -3377,7 +3377,7 @@ def test_push_downloaded_requirement_from_pypi_duplicated(mock_get_info, mock_up
         mock_upload.assert_called_once_with(pip_repo_name, path)
         assert dependency == expected_dependency
     else:
-        with pytest.raises(NetworkError, match="stub"):
+        with pytest.raises(UploadError, match="stub"):
             pip._push_downloaded_requirement(req, pip_repo_name, raw_repo_name)
 
 
@@ -3432,7 +3432,7 @@ def test_push_downloaded_requirement_non_pypi(mock_upload, dev, kind):
 def test_push_downloaded_requirement_non_pypi_duplicated(
     mock_get_info, mock_upload, kind, uploaded
 ):
-    mock_upload.side_effect = NetworkError("stub")
+    mock_upload.side_effect = UploadError("stub")
     mock_get_info.return_value = uploaded
     pip_repo_name = "test-pip-hosted"
     raw_repo_name = "test-pip-raw"
@@ -3474,7 +3474,7 @@ def test_push_downloaded_requirement_non_pypi_duplicated(
         mock_upload.assert_called_once_with(raw_repo_name, path, dest_dir, filename, True)
         assert dependency == expected_dependency
     else:
-        with pytest.raises(NetworkError, match="stub"):
+        with pytest.raises(UploadError, match="stub"):
             pip._push_downloaded_requirement(req, pip_repo_name, raw_repo_name)
 
 


### PR DESCRIPTION
Pip package manager requests should not fail on already uploaded package

CLOUDBLD-10907

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
