### PR TITLE
RubyGems: Checkout branches for local Git repos

### DIFF
--- a/cachito/errors.py
+++ b/cachito/errors.py
@@ -33,6 +33,10 @@ class UnknownHashAlgorithm(CachitoError):
     """The hash algorithm is unknown by Cachito."""
 
 
+class GitError(CachitoError):
+    """An error was encountered during manipulation with a Git repository."""
+
+
 # Request error classifiers
 class ClientError(Exception):
     """Client Error."""


### PR DESCRIPTION
Current implementation doesn't support Git dependencies specified with
`branch:` tag, because in order for local Git dependency redirection to
work, branch has to be checked out when it's specified (otherwise it
doesn't have to be).

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
