### PR TITLE
Fix RubyGems Request JSON metadata

### DIFF
--- a/cachito/workers/tasks/rubygems.py
+++ b/cachito/workers/tasks/rubygems.py
@@ -181,10 +181,10 @@ def cleanup_metadata(dependencies: list[dict]):
 
     :param list dependencies: which should be processed
     :return: list of dependencies where each dependency is represented by a dictionary
-        with the following keys: name, version, type, kind
+        with the following keys: name, version, type
     :rtype list[dict]:
     """
     return [
-        {"name": dep["name"], "version": dep["version"], "type": dep["type"], "kind": dep["kind"]}
+        {"name": dep["name"], "version": dep["version"], "type": dep["type"]}
         for dep in dependencies
     ]

--- a/tests/test_workers/test_tasks/test_rubygems.py
+++ b/tests/test_workers/test_tasks/test_rubygems.py
@@ -183,6 +183,7 @@ def test_fetch_rubygems_source(
     expected = pkg_data["package"].copy()
     expected_dependencies = pkg_data["dependencies"]
     del expected_dependencies[0]["path"]
+    del expected_dependencies[0]["kind"]
     expected["dependencies"] = expected_dependencies
     if not package_subpath or package_subpath == os.curdir:
         del expected["path"]


### PR DESCRIPTION
Commit 281b5217111afee923e14f901d1b15b49cd47086 moved cleanup_metatada()
to a different file but it added a `kind` key, which doesn't match
the documentation and should be deleted.

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
