### PR TITLE
Fix RubyGems GIT dependencies

### DIFF
--- a/cachito/workers/pkg_managers/rubygems.py
+++ b/cachito/workers/pkg_managers/rubygems.py
@@ -424,7 +424,7 @@ def checkout_branch(dep: dict):
     try:
         repo = Repo(dep["path"] / "app")
         git = repo.git
-        git.checkout("HEAD", b=dep["branch"])
+        git.checkout("HEAD", B=dep["branch"])
     except CheckoutError:
         raise GitError(f"Couldn't checkout branch {dep['branch']} at {dep['path'] / 'app'}")
     except Exception:

--- a/tests/test_workers/test_pkg_managers/test_rubygems.py
+++ b/tests/test_workers/test_pkg_managers/test_rubygems.py
@@ -921,7 +921,7 @@ def test_checkout_branch(mock_repo):
     rubygems.checkout_branch({"path": Path("/yo"), "branch": "b"})
 
     mock_repo.assert_called_with(Path("/yo/app"))
-    mock_repo.return_value.git.checkout.assert_called_once_with("HEAD", b="b")
+    mock_repo.return_value.git.checkout.assert_called_once_with("HEAD", B="b")
 
 
 @mock.patch("cachito.workers.pkg_managers.rubygems.Repo")


### PR DESCRIPTION
When Cachito worker downloads GIT dependency, the downloaded Git repository is checked out at a proper revision (according to the `Gemfile.lock`), but it's not checked out at a proper branch. Until now, Cachito was using `git checkout -b <branch name>`, however, this didn't work for cases when the branch already existed (e.g. downloaded repositories usually contained `master` branch and if the `Gemfile.lock` specified `master` branch too, this command tried to create a branch that already existed).

To fix this, `-B` option should be used in `git checkout`, because in case of an existing branch, it checks out the branch and resets it to the current commit and no error is raised.

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
