### PR TITLE
Fix typing issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,7 @@ packages = ["cachi2"]
 
 [tool.setuptools_scm]
 version_scheme = "post-release"
+
+[[tool.mypy.overrides]]
+module = ["semver"]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:mypy]
 commands =
     pip install mypy  # cannot be in deps due requirement of hashes
-    mypy -p cachi2 --install-types --non-interactive --ignore-missing-imports
+    mypy -p cachi2 --install-types --non-interactive
 
 [testenv:integration]
 basepython = python3


### PR DESCRIPTION
* don't ignore all missing imports, only the necessary ones
* add missing `__init__.py`, which was causing mypy to skip our code
* fix type issues in that code

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
