### PR TITLE
Improve the isort experience

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -64,6 +64,7 @@ jobs:
         tox_env:
           - bandit
           - black
+          - isort
           - flake8
           - mypy
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ target-version = ['py310']
 # Leave this empty to avoid a bug introduced in setuptools-git-versioning 1.8.0
 # See https://github.com/dolfinus/setuptools-git-versioning/blob/df461e6b33493642ef39b96f8c5d68689f304bf7/setuptools_git_versioning.py#L180
 [tool.setuptools-git-versioning]
+
+[tool.isort]
+profile = "black"
+line_length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,4 @@ target-version = ['py310']
 [tool.isort]
 profile = "black"
 line_length = 100
+extend_skip_glob = ["cachito/web/migrations/*"]

--- a/tox.ini
+++ b/tox.ini
@@ -63,12 +63,6 @@ per-file-ignores =
     tests/*:D101,D102,D103
     cachito/web/migrations/*:D103
 
-[isort]
-line_length = 100
-# Vertical hanging indent
-multi_line_output = 3
-include_trailing_comma = true
-
 [testenv:bandit]
 skip_install = true
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = bandit,black,flake8,mypy,python3.10
+envlist = bandit,black,isort,flake8,mypy,python3.10
 
 [gh-actions]
 python =
@@ -42,12 +42,18 @@ commands =
     # Use shorter line length for scripts
     black --check --diff bin --line-length=88
 
+[testenv:isort]
+skip_install = true
+deps =
+    isort[colors]
+commands =
+    isort --check --diff --color cachito tests
+
 [testenv:flake8]
 skip_install = true
 deps =
     flake8==3.9.2
     flake8-docstrings==1.6.0
-    flake8-isort==4.0.0
 commands =
     flake8
 


### PR DESCRIPTION
* set line_length=100 to match black
* run it outside of flake8 to improve the atrocious error messages

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
