### PR TITLE
CVE-2007-4559 Patch

### DIFF
--- a/cachito/workers/__init__.py
+++ b/cachito/workers/__init__.py
@@ -4,6 +4,8 @@ import json
 import logging
 import re
 import subprocess  # nosec
+from pathlib import Path
+from tarfile import ExtractError, TarFile
 from typing import Iterator
 
 from cachito.errors import SubprocessCallError
@@ -59,3 +61,29 @@ def load_json_stream(s: str) -> Iterator:
     while match := non_whitespace.search(s, i):
         obj, i = decoder.raw_decode(s, match.start())
         yield obj
+
+
+def safe_extract(tar: TarFile, path: str = ".", *, numeric_owner: bool = False):
+    """
+    CVE-2007-4559 replacement for extract() or extractall().
+
+    By using extract() or extractall() on a tarfile object without sanitizing input,
+    a maliciously crafted .tar file could perform a directory path traversal attack.
+    The patch essentially checks to see if all tarfile members will be
+    extracted safely and throws an exception otherwise.
+
+    :param tarfile tar: the tarfile to be extracted.
+    :param str path: specifies a different directory to extract to.
+    :param numeric_owner: if True, only the numbers for user/group names are used and not the names.
+    :raise ExtractError: if there is a Traversal Path Attempt in the Tar File.
+    """
+    abs_path = Path(path).resolve()
+    for member in tar.getmembers():
+
+        member_path = Path(path).joinpath(member.name)
+        abs_member_path = member_path.resolve()
+
+        if not abs_member_path.is_relative_to(abs_path):
+            raise ExtractError("Attempted Path Traversal in Tar File")
+
+    tar.extractall(path, numeric_owner=numeric_owner)

--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -16,7 +16,7 @@ from cachito.errors import (
     RepositoryAccessError,
     SubprocessCallError,
 )
-from cachito.workers import run_cmd
+from cachito.workers import run_cmd, safe_extract
 from cachito.workers.paths import SourcesDir
 
 log = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ class Git(SCM):
             repo_path = os.path.join(temp_dir, "app")
             try:
                 with tarfile.open(self.sources_dir.archive_path, mode="r:gz") as tar:
-                    tar.extractall(temp_dir)
+                    safe_extract(tar, temp_dir)
             except (tarfile.ExtractError, zlib.error, OSError) as exc:
                 log.error(err_msg["log"], self.sources_dir.archive_path, exc)
                 raise SubprocessCallError(err_msg["exception"])
@@ -202,7 +202,7 @@ class Git(SCM):
         """
         with tempfile.TemporaryDirectory(prefix="cachito-") as temp_dir:
             with tarfile.open(previous_archive, mode="r:gz") as tar:
-                tar.extractall(temp_dir)
+                safe_extract(tar, temp_dir)
 
             repo = git.Repo(os.path.join(temp_dir, "app"))
             try:

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -19,6 +19,7 @@ from cachito.errors import (
     UnsupportedFeature,
     ValidationError,
 )
+from cachito.workers import safe_extract
 from cachito.workers.errors import CachitoCalledProcessError
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers import gomod
@@ -694,7 +695,7 @@ def test_get_golang_version(tmpdir, module_suffix, ref, expected, subpath):
     # Extract the Git repository of a Go module to verify the correct versions are computed
     repo_archive_path = os.path.join(os.path.dirname(__file__), "golang_git_repo.tar.gz")
     with tarfile.open(repo_archive_path, "r:*") as archive:
-        archive.extractall(tmpdir)
+        safe_extract(archive, tmpdir)
     repo_path = os.path.join(tmpdir, "golang_git_repo")
 
     module_name = f"github.com/mprahl/test-golang-pseudo-versions{module_suffix}"

--- a/tests/test_workers/test_scm.py
+++ b/tests/test_workers/test_scm.py
@@ -60,6 +60,7 @@ def test_clone_and_archive(
     # Mock the archive being created
     mock_exists.return_value = True
     mock_tarfile = mock.Mock()
+    mock_tarfile.getmembers.return_value = []
     mock_tarfile_open.return_value.__enter__.return_value = mock_tarfile
     # Mock the commit being returned from repo.commit(self.ref)
     mock_commit = mock.Mock()
@@ -274,6 +275,7 @@ def test_update_and_archive(
     # Mock the archive being created
     mock_exists.return_value = True
     mock_tarfile = mock.Mock()
+    mock_tarfile.getmembers.return_value = []
     mock_tarfile_open.return_value.__enter__.return_value = mock_tarfile
 
     # Mock the tempfile.TemporaryDirectory context manager

--- a/tests/test_workers/test_worker_utils.py
+++ b/tests/test_workers/test_worker_utils.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import json
+import tarfile
 from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest
 
-from cachito.workers import load_json_stream, run_cmd
+from cachito.workers import load_json_stream, run_cmd, safe_extract
 
 
 @pytest.mark.parametrize(
@@ -62,3 +63,13 @@ def test_load_json_stream_invalid():
     assert next(data) == 2
     with pytest.raises(json.JSONDecodeError, match="Expecting value: line 1 column 5"):
         next(data)
+
+
+def test_safe_extract(tmp_path):
+
+    with tarfile.open(tmp_path / "fake.tar", "w") as tf:
+        tf.add("README.md", "../README.md")
+
+    with tarfile.open(tmp_path / "fake.tar") as tar:
+        with pytest.raises(tarfile.ExtractError):
+            safe_extract(tar, tmp_path)


### PR DESCRIPTION
CVE-2007-4559 is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack.

This issue was initially described in [this](https://github.com/containerbuildsystem/cachito/pull/740) pull request.

CLOUDBLD-11296

Signed-off-by: Felipe Campos <fdealmei@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
