### PR TITLE
switch to setuptools-scm for versioning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .env/
-.git/
 .idea/
 .pytest_cache/
 .tox/

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -8,6 +8,7 @@ RUN dnf -y install \
     --setopt=tsflags=nodocs \
     httpd \
     gcc \
+    git-core \
     libffi-devel \
     libpq-devel \
     mod_auth_gssapi \

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -24,7 +24,8 @@ COPY ./docker/cachito-httpd.conf /etc/httpd/conf/httpd.conf
 
 RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
     && pip3 install -r requirements-web.txt --no-deps --no-cache-dir --require-hashes \
-    && pip3 install . --no-deps --no-cache-dir
+    && pip3 install . --no-deps --no-cache-dir \
+    && rm -rf .git
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/directory-hash/ca-bundle.crt

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -24,7 +24,8 @@ COPY . .
 
 # All the requirements except pyarn should already be installed
 RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
-    && pip3 install . --no-deps --no-cache-dir
+    && pip3 install . --no-deps --no-cache-dir \
+    && rm -rf .git
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/directory-hash/ca-bundle.crt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,6 @@
 line-length = 100
 target-version = ['py310']
 
-# Leave this empty to avoid a bug introduced in setuptools-git-versioning 1.8.0
-# See https://github.com/dolfinus/setuptools-git-versioning/blob/df461e6b33493642ef39b96f8c5d68689f304bf7/setuptools_git_versioning.py#L180
-[tool.setuptools-git-versioning]
-
 [tool.isort]
 profile = "black"
 line_length = 100

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,8 @@ setup(
     ],
     license="GPLv3+",
     python_requires=">=3.10",
-    setup_requires=['setuptools-git-versioning'],
-    setuptools_git_versioning={
-        "enabled": True,
-        "dev_template": "{tag}.post{ccount}+git.{sha}",
+    use_scm_version={
+        "version_scheme": "post-release",
     },
+    setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
A change was introduced in setuptools-git-versioning 1.12 where leading, non-numeric characters (except v) are no longer allowed in the version string. This is causing issues with our tag-based versioning.

Switch to use setuptools-scm instead.

CLOUDBLD-11280

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- N/A Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- N/A README updated (if worker configuration changed, or if applicable)
