### PR TITLE
workflow: use checkout action version 3

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Install required packages
       run: |
         sudo apt-get install -y \
@@ -69,7 +69,9 @@ jobs:
           - mypy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Install required packages
       run: |
         sudo apt-get install -y \
@@ -94,7 +96,7 @@ jobs:
           - Dockerfile-api
           - Dockerfile-workers
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: hadolint/hadolint-action@v1.5.0
       with:
         dockerfile: docker/${{ matrix.dockerfile }}
@@ -108,7 +110,7 @@ jobs:
     name: Swagger Editor Validator Remote
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Validate OpenAPI definition
         uses: char0n/swagger-editor-validate@v1.2.1
         with:
@@ -122,7 +124,9 @@ jobs:
     - linters
     - hadolint
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Install required packages
       run: |
         sudo apt-get install -y \


### PR DESCRIPTION
Older versions run with unsupported nodejs

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- N/A Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- N/A README updated (if worker configuration changed, or if applicable)
