### PR TITLE
Ensure go.sum is generated before calling `go mod vendor`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .env/
-.git/
 .idea/
 .pytest_cache/
 .tox/

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -200,11 +200,10 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
         should_vendor, can_make_changes = _should_vendor_deps(
             flags, app_source_path, worker_config.cachito_gomod_strict_vendor
         )
+        log.info("Downloading the gomod dependencies")
+        run_download_cmd(("go", "mod", "download"), run_params)
         if should_vendor:
             _vendor_deps(run_params, can_make_changes, git_dir_path)
-        else:
-            log.info("Downloading the gomod dependencies")
-            run_download_cmd(("go", "mod", "download"), run_params)
         if "force-gomod-tidy" in flags or dep_replacements:
             run_gomod_cmd(("go", "mod", "tidy"), run_params)
 

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -8,6 +8,7 @@ RUN dnf -y install \
     --setopt=tsflags=nodocs \
     httpd \
     gcc \
+    git-core \
     libffi-devel \
     libpq-devel \
     mod_auth_gssapi \

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -24,7 +24,8 @@ COPY ./docker/cachito-httpd.conf /etc/httpd/conf/httpd.conf
 
 RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
     && pip3 install -r requirements-web.txt --no-deps --no-cache-dir --require-hashes \
-    && pip3 install . --no-deps --no-cache-dir
+    && pip3 install . --no-deps --no-cache-dir \
+    && rm -rf .git
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/directory-hash/ca-bundle.crt

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -24,7 +24,8 @@ COPY . .
 
 # All the requirements except pyarn should already be installed
 RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
-    && pip3 install . --no-deps --no-cache-dir
+    && pip3 install . --no-deps --no-cache-dir \
+    && rm -rf .git
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/directory-hash/ca-bundle.crt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,6 @@
 line-length = 100
 target-version = ['py310']
 
-# Leave this empty to avoid a bug introduced in setuptools-git-versioning 1.8.0
-# See https://github.com/dolfinus/setuptools-git-versioning/blob/df461e6b33493642ef39b96f8c5d68689f304bf7/setuptools_git_versioning.py#L180
-[tool.setuptools-git-versioning]
-
 [tool.isort]
 profile = "black"
 line_length = 100

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,8 @@ setup(
     ],
     license="GPLv3+",
     python_requires=">=3.10",
-    setup_requires=['setuptools-git-versioning'],
-    setuptools_git_versioning={
-        "enabled": True,
-        "dev_template": "{tag}.post{ccount}+git.{sha}",
+    use_scm_version={
+        "version_scheme": "post-release",
     },
+    setup_requires=['setuptools_scm'],
 )

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -373,6 +373,7 @@ def test_resolve_gomod_vendor_dependencies(
 
     # Mock the "subprocess.run" calls
     run_side_effects = []
+    run_side_effects.append(mock.Mock(returncode=0, stdout=None))  # go mod download
     run_side_effects.append(mock.Mock(returncode=0, stdout=None))  # go mod vendor
     if force_gomod_tidy:
         run_side_effects.append(mock.Mock(returncode=0, stdout=None))  # go mod tidy
@@ -399,7 +400,8 @@ def test_resolve_gomod_vendor_dependencies(
         request["flags"].append("force-gomod-tidy")
     gomod = resolve_gomod(archive_path, request)
 
-    assert mock_run.call_args_list[0][0][0] == ("go", "mod", "vendor")
+    assert mock_run.call_args_list[0][0][0] == ("go", "mod", "download")
+    assert mock_run.call_args_list[1][0][0] == ("go", "mod", "vendor")
     # when vendoring, go list should be called without -mod readonly
     assert mock_run.call_args_list[-2][0][0] == ["go", "list", "-find", "./..."]
     assert gomod["module"] == sample_package


### PR DESCRIPTION
As of go 1.18, `go.sum` is no longer updated when `go mod vendor` is called [1]. In order to maintain backwards compatibility, we should ensure that the file is updated before vendoring.

[1]: https://tip.golang.org/doc/go1.18

Signed-off-by: arewm <arewm@users.noreply.github.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
