### PR TITLE
Fix asyncio behavior when a request fails

### DIFF
--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -187,8 +187,17 @@ async def async_download_binary_file(
                     if not chunk:
                         break
                     f.write(chunk)
-    except Exception as e:
-        raise NetworkError(f"Could not download {url}: {e}")
+
+    except Exception as exception:
+        log.error(f"Unsuccessful download: {tarball_name}")
+        # "from None" since we have the exception context in the logs
+        raise NetworkError(
+            (
+                f"Could not download {tarball_name} from {url}. "
+                f"exception_name: {exception.__class__.__name__}, "
+                f"details: {exception}"
+            )
+        ) from None
 
     log.debug(f"Download completed - {tarball_name}")
 

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -276,7 +276,7 @@ async def test_get_dependecies(mock_async_download_binary_file):
         "http://nexus:8081/repository/cachito-yarn-53/",
         "/tmp/cachito-archives/bundles/temp/53/deps/yarn",
         deps_list,
-        5,
+        conf.cachito_js_concurrency_limit,
         conf.cachito_nexus_username,
         conf.cachito_nexus_password,
     )


### PR DESCRIPTION
When there is a failure while downloading dependencies, Cachito should not continue creating download tasks for the remaining dependencies, but cancel the Request as a whole.

Log of a failed request -> https://pastebin.com/mTqpPtiL
Repo used to create a failed request -> https://github.com/fepas/cachito-yarn-with-not-found-deps.git

CLOUDBLD-9007

Signed-off-by: Felipe Campos <fdealmei@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] OpenAPI schema is updated (if applicable)
- [x] DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
