### PR TITLE
bump flask-migrate from 3.1.0 to 4.0.0

### DIFF
--- a/cachito/web/migrations/env.py
+++ b/cachito/web/migrations/env.py
@@ -83,7 +83,6 @@ def run_migrations_online():
             connection=connection,
             target_metadata=target_metadata,
             process_revision_directives=process_revision_directives,
-            render_as_batch=True,
             **current_app.extensions["migrate"].configure_args,
         )
 

--- a/requirements-web.txt
+++ b/requirements-web.txt
@@ -25,9 +25,9 @@ flask-login==0.6.2 \
     --hash=sha256:1ef79843f5eddd0f143c2cd994c1b05ac83c0401dc6234c143495af9a939613f \
     --hash=sha256:c0a7baa9fdc448cdd3dd6f0939df72eec5177b2f7abe6cb82fc934d29caac9c3
     # via -r requirements-web.in
-flask-migrate==3.1.0 \
-    --hash=sha256:57d6060839e3a7f150eaab6fe4e726d9e3e7cffe2150fb223d73f92421c6d1d9 \
-    --hash=sha256:a6498706241aba6be7a251078de9cf166d74307bca41a4ca3e403c9d39e2f897
+flask-migrate==4.0.0 \
+    --hash=sha256:2a301c3040af6844f29d9149abe428a0f08ebc8fa149e72113bbb36fa341920a \
+    --hash=sha256:e75a46b657e3062296b9f6e92f31e19662f76cfee8abd6ae94640cbcb79fe016
     # via -r requirements-web.in
 flask-sqlalchemy==2.5.1 \
     --hash=sha256:2bda44b43e7cacb15d4e05ff3cc1f8bc97936cc464623424102bfc2c35e95912 \


### PR DESCRIPTION
There is an issue with the [dependabot PR](https://github.com/containerbuildsystem/cachito/pull/759) for this, since render_as_batch=True is now the default: https://github.com/miguelgrinberg/Flask-Migrate/commit/a3085b34e5b1865d2b773248b37468764df7c312

```
          with connectable.connect() as connection:
  >           context.configure(
                  connection=connection,
                  target_metadata=target_metadata,
                  process_revision_directives=process_revision_directives,
                  render_as_batch=True,
                  **current_app.extensions["migrate"].configure_args,
              )
  E           TypeError: alembic.context.configure() got multiple values for keyword argument 'render_as_batch'
```

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)