### PR TITLE
cleanup nexus for rubygems requests

### DIFF
--- a/cachito/web/api_v1.py
+++ b/cachito/web/api_v1.py
@@ -531,7 +531,7 @@ def patch_request(request_id):
         new_state = payload["state"]
         delete_bundle = new_state == "stale" and request.state.state_name != "failed"
         if new_state in ("stale", "failed"):
-            for pkg_manager in ["npm", "pip", "yarn"]:
+            for pkg_manager in ["npm", "pip", "rubygems", "yarn"]:
                 if any(p.name == pkg_manager for p in request.pkg_managers):
                     cleanup_nexus.append(pkg_manager)
         delete_bundle_temp = new_state in ("complete", "failed", "stale")


### PR DESCRIPTION
Add rubygems to the list of package managers we cleanup nexus content for

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
