### PR TITLE
Fixes CodeQL alerts

### DIFF
--- a/cachito/web/auth.py
+++ b/cachito/web/auth.py
@@ -48,7 +48,7 @@ def _get_cert_dn(request):
         current_app.logger.debug(
             "The SSL_CLIENT_VERIFY environment variable was set to %s", ssl_client_verify
         )
-        return
+        return None
 
     return request.environ.get("SSL_CLIENT_S_DN")
 
@@ -75,7 +75,7 @@ def load_user_from_request(request):
                 "The REMOTE_USER environment variable wasn't set on the request, but the "
                 "LOGIN_DISABLED configuration is set to True."
             )
-        return
+        return None
 
     current_app.logger.info(f'The user "{username}" was authenticated successfully by httpd')
     user = User.get_or_create(username)

--- a/cachito/web/models.py
+++ b/cachito/web/models.py
@@ -698,6 +698,7 @@ class RequestState(db.Model):
         """Get the state's display name."""
         if self.state:
             return RequestStateMapping(self.state).name
+        return None
 
     def __repr__(self):
         return '<RequestState id={} state="{}" request_id={}>'.format(

--- a/cachito/workers/nexus.py
+++ b/cachito/workers/nexus.py
@@ -189,6 +189,7 @@ def get_ca_cert():
     if config.cachito_nexus_ca_cert and os.path.exists(config.cachito_nexus_ca_cert):
         with open(config.cachito_nexus_ca_cert, "r") as f:
             return f.read()
+    return None
 
 
 def get_component_info_from_nexus(

--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -323,6 +323,7 @@ def find_package_json(package_archive):
                     package_archive,
                 )
                 return member.name
+        return None
 
 
 def generate_npmrc_content(proxy_repo_url, username, password, custom_ca_path=None):

--- a/cachito/workers/tasks/pip.py
+++ b/cachito/workers/tasks/pip.py
@@ -189,7 +189,7 @@ def _get_custom_requirement_config_file(
 
     if not differs_from_original:
         # No vcs or url dependencies. No need for a custom requirements file
-        return
+        return None
 
     cachito_requirement_file = PipRequirementsFile.from_requirements_and_options(
         cachito_requirements, original_requirement_file.options

--- a/cachito/workers/tasks/utils.py
+++ b/cachito/workers/tasks/utils.py
@@ -140,7 +140,7 @@ def runs_if_request_in_progress(task_fn):
                 task_fn.__name__,
                 request_state,
             )
-            return
+            return None
 
         return task_fn(*args, **kwargs)
 

--- a/tests/integration/test_using_cached_dependencies.py
+++ b/tests/integration/test_using_cached_dependencies.py
@@ -528,3 +528,4 @@ def update_main_repo(env_data, repo_dir, tmpdir, new_dep_commits, dep_repo):
         return {
             "FIRST_DEP_COMMIT": new_dep_commits[0],
         }
+    return None

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -1328,7 +1328,6 @@ def test_set_state(state, app, client, db, worker_auth_env, tmpdir):
     db.session.commit()
 
     request_id = 1
-    state = state
     state_reason = "Some status"
     payload = {"state": state, "state_reason": state_reason}
 

--- a/tests/test_api_v1.py
+++ b/tests/test_api_v1.py
@@ -8,7 +8,6 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Dict, List, Union
 from unittest import mock
-from urllib.parse import urlencode
 
 import flask
 import kombu.exceptions
@@ -2741,7 +2740,7 @@ def test_get_request_metrics(
             db.session.add(state)
         db.session.commit()
 
-    rv = client.get(f"/api/v1/request-metrics?{urlencode(finished_filter)}")
+    rv = client.get(f"/api/v1/request-metrics?{urllib.parse.urlencode(finished_filter)}")
     assert rv.status_code == response_status
     if response_status == 200:
         if not final_state:

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -67,6 +67,8 @@ def test_validate_celery_config_failure(mock_isdir, bundles_dir, sources_dir):
     elif sources_dir:
         celery_app.conf.cachito_sources_dir = "/tmp/some-path/sources"
         dir_name = "cachito_bundles_dir"
+    else:
+        raise Exception("Invalid test configuration.")
 
     setattr(celery_app.conf, dir_name, None)
     expected = f'The configuration "{dir_name}" must be set to an existing directory'

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -2,7 +2,6 @@
 import os
 import re
 import tarfile
-import textwrap
 from contextlib import nullcontext
 from tempfile import TemporaryDirectory as tempDir
 from textwrap import dedent
@@ -1195,7 +1194,7 @@ def test_vendor_deps(mock_vendor_changed, mock_run_cmd, can_make_changes, vendor
         (
             {},
             {"vendor": {"modules.txt": "foo v1.0.0\n"}},
-            textwrap.dedent(
+            dedent(
                 """
                 --- /dev/null
                 +++ b/{subpath}vendor/modules.txt
@@ -1208,7 +1207,7 @@ def test_vendor_deps(mock_vendor_changed, mock_run_cmd, can_make_changes, vendor
         (
             {"vendor": {"modules.txt": "foo v1.0.0\n"}},
             {"vendor": {"modules.txt": "foo v2.0.0\n"}},
-            textwrap.dedent(
+            dedent(
                 """
                 --- a/{subpath}vendor/modules.txt
                 +++ b/{subpath}vendor/modules.txt
@@ -1222,7 +1221,7 @@ def test_vendor_deps(mock_vendor_changed, mock_run_cmd, can_make_changes, vendor
         (
             {},
             {"vendor": {"some_file": "foo"}},
-            textwrap.dedent(
+            dedent(
                 """
                 A\t{subpath}vendor/some_file
                 """
@@ -1232,7 +1231,7 @@ def test_vendor_deps(mock_vendor_changed, mock_run_cmd, can_make_changes, vendor
         (
             {"vendor": {"some_file": "foo"}},
             {"vendor": {"some_file": "bar", "other_file": "baz"}},
-            textwrap.dedent(
+            dedent(
                 """
                 A\t{subpath}vendor/other_file
                 M\t{subpath}vendor/some_file
@@ -1245,7 +1244,7 @@ def test_vendor_deps(mock_vendor_changed, mock_run_cmd, can_make_changes, vendor
         (
             {".gitignore": "vendor/"},
             {"vendor": {"some_file": "foo"}},
-            textwrap.dedent(
+            dedent(
                 """
                 A\t{subpath}vendor/some_file
                 """

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -3392,11 +3392,21 @@ def test_push_downloaded_requirement_non_pypi(mock_upload, dev, kind):
     if kind == "vcs":
         version = f"git+https://github.com/spam/eggs@{GIT_REF}"
         raw_component = f"eggs/eggs-external-gitcommit-{GIT_REF}.tar.gz"
+        additional_keys = {
+            "url": "https://github.com/spam/eggs",
+            "host": "github.com",
+            "namespace": "spam",
+            "repo": "eggs",
+            "ref": GIT_REF,
+        }
     elif kind == "url":
         url = "https://example.org/eggs.tar.gz"
         url_with_hash = f"{url}#cachito_hash=sha256:abcdef"
         version = url_with_hash
         raw_component = "eggs/eggs.tar.gz"
+        additional_keys = {"original_url": url, "url_with_hash": url_with_hash}
+    else:
+        raise Exception("Invalid dependency kind.")
 
     dest_dir, filename = raw_component.rsplit("/", 1)
     req = {
@@ -3406,16 +3416,6 @@ def test_push_downloaded_requirement_non_pypi(mock_upload, dev, kind):
         "kind": kind,
         "dev": dev,
     }
-    if kind == "vcs":
-        additional_keys = {
-            "url": "https://github.com/spam/eggs",
-            "host": "github.com",
-            "namespace": "spam",
-            "repo": "eggs",
-            "ref": GIT_REF,
-        }
-    elif kind == "url":
-        additional_keys = {"original_url": url, "url_with_hash": url_with_hash}
 
     req.update(additional_keys)
 
@@ -3441,11 +3441,21 @@ def test_push_downloaded_requirement_non_pypi_duplicated(
     if kind == "vcs":
         version = f"git+https://github.com/spam/eggs@{GIT_REF}"
         raw_component = f"eggs/eggs-external-gitcommit-{GIT_REF}.tar.gz"
+        additional_keys = {
+            "url": "https://github.com/spam/eggs",
+            "host": "github.com",
+            "namespace": "spam",
+            "repo": "eggs",
+            "ref": GIT_REF,
+        }
     elif kind == "url":
         url = "https://example.org/eggs.tar.gz"
         url_with_hash = f"{url}#cachito_hash=sha256:abcdef"
         version = url_with_hash
         raw_component = "eggs/eggs.tar.gz"
+        additional_keys = {"original_url": url, "url_with_hash": url_with_hash}
+    else:
+        raise Exception("Invalid dependency kind.")
 
     dest_dir, filename = raw_component.rsplit("/", 1)
     req = {
@@ -3455,16 +3465,6 @@ def test_push_downloaded_requirement_non_pypi_duplicated(
         "kind": kind,
         "dev": False,
     }
-    if kind == "vcs":
-        additional_keys = {
-            "url": "https://github.com/spam/eggs",
-            "host": "github.com",
-            "namespace": "spam",
-            "repo": "eggs",
-            "ref": GIT_REF,
-        }
-    elif kind == "url":
-        additional_keys = {"original_url": url, "url_with_hash": url_with_hash}
 
     req.update(additional_keys)
 

--- a/tests/test_workers/test_pkg_managers/test_pip.py
+++ b/tests/test_workers/test_pkg_managers/test_pip.py
@@ -1915,7 +1915,9 @@ class TestPipRequirementsFile:
         pip.PipRequirementsFile.from_requirements_and_options(
             new_requirements, pip_requirements.options
         ).write(new_file_path.strpath)
-        assert open(new_file_path.strpath).read() == expected_new_file
+
+        with open(new_file_path.strpath) as f:
+            assert f.read() == expected_new_file
 
         # Parse the newly generated requirements file to ensure it's parsed correctly.
         new_pip_requirements = pip.PipRequirementsFile(new_file_path.strpath)
@@ -1956,7 +1958,8 @@ class TestPipRequirementsFile:
         assert not original_file_path.exists()
         pip_requirements.write()
         assert original_file_path.exists()
-        assert open(original_file_path.strpath).read() == content
+        with open(original_file_path.strpath) as f:
+            assert f.read() == content
 
         # Verify file can be written to an alternative location
         original_file_path.remove()
@@ -1964,7 +1967,8 @@ class TestPipRequirementsFile:
         pip_requirements.write(new_file_path.strpath)
         assert not original_file_path.exists()
         assert new_file_path.exists()
-        assert open(new_file_path.strpath).read() == content
+        with open(new_file_path.strpath) as f:
+            assert f.read() == content
 
     def test_write_requirements_file_unspecified_path(self):
         """Test PipRequirementsFile.write method validation error."""

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -712,7 +712,8 @@ def test_resolve_yarn(
             n_pop_calls += 1
 
             if expected_keys:
-                assert key == expected_keys.pop()
+                popped_key = expected_keys.pop()
+                assert key == popped_key
             else:
                 assert False
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
