### PR TITLE
Remove dependency on `mapfile`

### DIFF
--- a/bin/cachito-download.sh
+++ b/bin/cachito-download.sh
@@ -80,10 +80,7 @@ inject_config_files () {
     curl -fsS "$request_url/configuration-files" > "$config_json"
 
     echo "Injecting configuration files to remote-source/"
-    # According to shellcheck, this is the proper way to save lines in an array
-    mapfile -t paths < <(jq '.[].path' -r < "$config_json")
-
-    for path in "${paths[@]}"; do
+    jq '.[].path' -r < "$config_json" | while IFS= read -r path; do
         # Show the path indented by 4 spaces
         echo "    $path"
         mkdir -p "$(dirname "$output_dir/remote-source/$path")"


### PR DESCRIPTION
`mapfile` doesn't exist on the standard bash version found on macOS

This should hopefully achieve the same without sacrificing too much in terms of readability...

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
