### PR TITLE
decrease cachito_js_concurrency_limit to 1

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -36,7 +36,7 @@ class Config(object):
     cachito_gomod_ignore_missing_gomod_file = True
     cachito_gomod_strict_vendor = False
     cachito_log_level = "INFO"
-    cachito_js_concurrency_limit = 5
+    cachito_js_concurrency_limit = 1
     cachito_nexus_ca_cert = "/etc/cachito/nexus_ca.pem"
     cachito_nexus_hoster_password: Optional[str] = None
     cachito_nexus_hoster_url: Optional[str] = None


### PR DESCRIPTION
Is this something we would rather change in our playbooks?

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
