### PR TITLE
use allowlist_externals key in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     -rrequirements.txt
     -rrequirements-web.txt
     -rrequirements-test.txt
-whitelist_externals =
+allowlist_externals =
     make
     mkdir
     rm


### PR DESCRIPTION
whitelist_externals was removed in tox 4

https://tox--2601.org.readthedocs.build/en/2601/faq.html#tox-4-removed-tox-ini-keys

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- n/a Draft release notes are updated before merging
