### PR TITLE
Fix usage of vendor deps for gomod-vendor-check

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -281,7 +281,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
 
         bundle_dir = RequestBundleDir(request["id"])
 
-        if "gomod-vendor" in flags:
+        if should_vendor:
             # Create an empty gomod cache in the bundle directory so that any Cachito
             # user does not have to guard against this directory not existing
             bundle_dir.gomod_download_dir.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
Make a fix for --gomod-vendor-check usage to create an empty gomod cache in the bundle directory so that any Cachi2 user does not have to guard against this directory not existing.

This change prevents from downloading dependencies to deps/ folder in output dir.

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- N/A README updated (if worker configuration changed, or if applicable)
- [x] Draft release notes are updated before merging
