### PR TITLE
pip_find_builddeps: force pip to use PEP 517

### DIFF
--- a/bin/pip_find_builddeps.py
+++ b/bin/pip_find_builddeps.py
@@ -31,7 +31,16 @@ class FindBuilddepsError(Exception):
 
 def _pip_download(requirements_files, output_file, tmpdir, no_cache):
     """Run pip download, write output to file."""
-    cmd = ["pip", "download", "-d", tmpdir, "--no-binary", ":all:", "--verbose"]
+    cmd = [
+        "pip",
+        "download",
+        "-d",
+        tmpdir,
+        "--no-binary",
+        ":all:",
+        "--use-pep517",
+        "--verbose",
+    ]
     if no_cache:
         cmd.append("--no-cache-dir")
     for file in requirements_files:


### PR DESCRIPTION
Without the --use-pep517 flag, build dependencies declared in the deprecated `setup_requires` way will not be found.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- N/A README updated (if worker configuration changed, or if applicable)
- N/A Draft release notes are updated before merging
