### PR TITLE
update integration test data for go 1.18.9

### DIFF
--- a/test_env_vars.yaml
+++ b/test_env_vars.yaml
@@ -125,6 +125,7 @@ get:
     - ["internal/poll", "go-package", null]
     - ["internal/race", "go-package", null]
     - ["internal/reflectlite", "go-package", null]
+    - ["internal/safefilepath", "go-package", null]
     - ["internal/singleflight", "go-package", null]
     - ["internal/syscall/execenv", "go-package", null]
     - ["internal/syscall/unix", "go-package", null]
@@ -243,4 +244,4 @@ various_packages:
   gomod:
     repo: https://github.com/cachito-testing/cachito-gomod-test
     ref: 1827221d787cbd1e979b339cfbbf59728eddf0d4
-    dependencies_count: 48
+    dependencies_count: 49

--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -205,6 +205,10 @@ gomod_cached_deps:
         replaces: null
         type: "go-package"
         version: null
+      - name: "internal/safefilepath"
+        replaces: null
+        type: "go-package"
+        version: null
       - name: "internal/syscall/execenv"
         replaces: null
         type: "go-package"
@@ -409,6 +413,10 @@ gomod_cached_deps:
       replaces: null
       type: "go-package"
       version: null
+    - name: "internal/safefilepath"
+      replaces: null
+      type: "go-package"
+      version: null
     - name: "internal/syscall/execenv"
       replaces: null
       type: "go-package"
@@ -560,6 +568,7 @@ gomod_cached_deps:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"

--- a/tests/integration/test_data/go_generate_packages.yaml
+++ b/tests/integration/test_data/go_generate_packages.yaml
@@ -96,6 +96,10 @@ go_generate:
       replaces: null
       type: go-package
       version: null
+    - name: internal/safefilepath
+      replaces: null
+      type: go-package
+      version: null
     - name: internal/syscall/execenv
       replaces: null
       type: go-package
@@ -263,6 +267,10 @@ go_generate:
           type: go-package
           version: null
         - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
           replaces: null
           type: go-package
           version: null
@@ -446,6 +454,10 @@ go_generate:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -589,6 +601,7 @@ go_generate:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -633,6 +646,7 @@ go_generate:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -738,6 +752,10 @@ go_generate_generated:
       type: go-package
       version: null
     - name: internal/reflectlite
+      replaces: null
+      type: go-package
+      version: null
+    - name: internal/safefilepath
       replaces: null
       type: go-package
       version: null
@@ -911,6 +929,10 @@ go_generate_generated:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -1068,6 +1090,10 @@ go_generate_generated:
           type: go-package
           version: null
         - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
           replaces: null
           type: go-package
           version: null
@@ -1252,6 +1278,10 @@ go_generate_generated:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -1390,6 +1420,7 @@ go_generate_generated:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -1436,6 +1467,7 @@ go_generate_generated:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -1480,6 +1512,7 @@ go_generate_generated:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -1589,6 +1622,10 @@ go_generate_imported:
       type: go-package
       version: null
     - name: internal/reflectlite
+      replaces: null
+      type: go-package
+      version: null
+    - name: internal/safefilepath
       replaces: null
       type: go-package
       version: null
@@ -1838,6 +1875,10 @@ go_generate_imported:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -1982,6 +2023,7 @@ go_generate_imported:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -2108,6 +2150,10 @@ go_generate_imported_generated:
       type: go-package
       version: null
     - name: internal/reflectlite
+      replaces: null
+      type: go-package
+      version: null
+    - name: internal/safefilepath
       replaces: null
       type: go-package
       version: null
@@ -2282,6 +2328,10 @@ go_generate_imported_generated:
           type: go-package
           version: null
         - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
           replaces: null
           type: go-package
           version: null
@@ -2465,6 +2515,10 @@ go_generate_imported_generated:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -2609,6 +2663,7 @@ go_generate_imported_generated:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -2654,6 +2709,7 @@ go_generate_imported_generated:
       - "pkg:golang/internal%2Fpoll"
       - "pkg:golang/internal%2Frace"
       - "pkg:golang/internal%2Freflectlite"
+      - "pkg:golang/internal%2Fsafefilepath"
       - "pkg:golang/internal%2Fsyscall%2Fexecenv"
       - "pkg:golang/internal%2Fsyscall%2Funix"
       - "pkg:golang/internal%2Ftestlog"

--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -123,6 +123,10 @@ with_deps:
         replaces: null
         type: go-package
         version: null
+      - name: internal/safefilepath
+        replaces: null
+        type: go-package
+        version: null
       - name: internal/syscall/execenv
         replaces: null
         type: go-package
@@ -314,6 +318,10 @@ with_deps:
           type: go-package
           version: null
         - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
           replaces: null
           type: go-package
           version: null
@@ -471,6 +479,7 @@ with_deps:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -577,6 +586,10 @@ vendored_with_flag:
         type: go-package
         version: null
       - name: internal/reflectlite
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/safefilepath
         replaces: null
         type: go-package
         version: null
@@ -771,6 +784,10 @@ vendored_with_flag:
           type: go-package
           version: null
         - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
           replaces: null
           type: go-package
           version: null
@@ -928,6 +945,7 @@ vendored_with_flag:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -1037,6 +1055,10 @@ implicit_gomod:
         type: go-package
         version: null
       - name: internal/reflectlite
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/safefilepath
         replaces: null
         type: go-package
         version: null
@@ -1234,6 +1256,10 @@ implicit_gomod:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -1388,6 +1414,7 @@ implicit_gomod:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -1537,6 +1564,10 @@ force_tidy_vendored:
         replaces: null
         type: go-package
         version: null
+      - name: internal/safefilepath
+        replaces: null
+        type: go-package
+        version: null
       - name: internal/syscall/execenv
         replaces: null
         type: go-package
@@ -1731,6 +1762,10 @@ force_tidy_vendored:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -1885,6 +1920,7 @@ force_tidy_vendored:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"

--- a/tests/integration/test_data/gomod_vendor_check.yaml
+++ b/tests/integration/test_data/gomod_vendor_check.yaml
@@ -91,6 +91,10 @@ correct_vendor:
         replaces: null
         type: go-package
         version: null
+      - name: internal/safefilepath
+        replaces: null
+        type: go-package
+        version: null
       - name: internal/syscall/execenv
         replaces: null
         type: go-package
@@ -282,6 +286,10 @@ correct_vendor:
           type: go-package
           version: null
         - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
           replaces: null
           type: go-package
           version: null
@@ -438,6 +446,7 @@ correct_vendor:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"
@@ -542,6 +551,10 @@ no_vendor:
         type: go-package
         version: null
       - name: internal/reflectlite
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/safefilepath
         replaces: null
         type: go-package
         version: null
@@ -739,6 +752,10 @@ no_vendor:
           replaces: null
           type: go-package
           version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
         - name: internal/syscall/execenv
           replaces: null
           type: go-package
@@ -892,6 +909,7 @@ no_vendor:
     - "pkg:golang/internal%2Fpoll"
     - "pkg:golang/internal%2Frace"
     - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
     - "pkg:golang/internal%2Fsyscall%2Fexecenv"
     - "pkg:golang/internal%2Fsyscall%2Funix"
     - "pkg:golang/internal%2Ftestlog"


### PR DESCRIPTION
The bump to golang 1.18.9 brought a new internal
package: safefilepath

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
