### PR TITLE
Add to makefile command to run only linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,14 @@ run-build run-rebuild: run-down
 # stop any containers, rebuild containers, and start it again
 run-build-start: run-rebuild run-start
 
+lint run-lint: 
+	PATH="${PWD}/venv/bin:${PATH}"
+	tox -e bandit
+	tox -e black
+	tox -e isort
+	tox -e flake8
+	tox -e mypy
+
 # Keep test target for backwards compatibility
 test test-unit:
 	PATH="${PWD}/venv/bin:${PATH}" tox


### PR DESCRIPTION
Running just the linters is something I did a lot in the last task, and with this command in the makefile, it will be much easier next time.

Signed-off-by: Felipe de Almeida <fdealmei@redhat.com>
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
