### PR TITLE
Small improvements to the API logging

### DIFF
--- a/cachito/web/config.py
+++ b/cachito/web/config.py
@@ -17,7 +17,9 @@ class Config(object):
     CACHITO_DEFAULT_PACKAGE_MANAGERS: List[str] = ["gomod"]
     # This sets the level of the "flask.app" logger, which is accessed from current_app.logger
     CACHITO_LOG_LEVEL = "INFO"
-    CACHITO_LOG_FORMAT = "[%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s] %(message)s"
+    CACHITO_LOG_FORMAT = (
+        "[%(asctime)s %(levelname)s %(module)s.%(funcName)s %(remote_addr)s] %(message)s"
+    )
     CACHITO_MAX_PER_PAGE = 100
     # Pairs of mutually exclusive package managers (cannot process the same package)
     CACHITO_MUTUALLY_EXCLUSIVE_PACKAGE_MANAGERS = [("npm", "yarn")]

--- a/docker/cachito-httpd.conf
+++ b/docker/cachito-httpd.conf
@@ -5,6 +5,7 @@ User apache
 Group apache
 DocumentRoot "/var/www/html"
 ErrorLog /dev/stderr
+LogFormat "[%{%F %T}t %u %h] \"%r\" %>s %b"
 TransferLog /dev/stdout
 LogLevel warn
 TypesConfig /etc/mime.types


### PR DESCRIPTION
This PR contains two small proposals to improve Cachito's logging:

1- Add the client IP to all API logs, since it's important data from a security perspective.

```
[2023-02-07 20:56:15 INFO api_v1.get_requests 10.89.0.6] Log message
```

2- Make Apache's logs more similar to Flask's, for better consistency:

```sh
#From:
10.89.0.6 - - [07/Feb/2023 20:23:59] "GET /api/v1/requests HTTP/1.1" 200 -
#To:
[2023-02-07 20:23:59 10.89.0.6] "GET /api/v1/requests HTTP/1.1" 200 -
```

I still wasn't able to properly validate the 2nd one (Apache is giving me a hard time in my local tests). But I want to know what you think about the proposals in the meantime.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
