### PR TITLE
upgrade development env nexus version to 3.45.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - 3000:3000
 
   nexus:
-    image: sonatype/nexus3:3.38.1
+    image: sonatype/nexus3:3.45.0
     environment:
       # Enable the script API. This is disabled by default in 3.21.2+.
       INSTALL4J_ADD_VM_PARAMS: -Dnexus.scripts.allowCreation=true -Dstorage.diskCache.diskFreeSpaceLimit=512


### PR DESCRIPTION
We encountered this issue for versions 3.42 -> 3.44: https://issues.sonatype.org/browse/NEXUS-35486

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
