### PR TITLE
Don't fail-fast linters

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -60,6 +60,7 @@ jobs:
   linters:
     name: Linters
     strategy:
+      fail-fast: false
       matrix:
         tox_env:
           - bandit
@@ -91,6 +92,7 @@ jobs:
     name: Hadolint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dockerfile:
           - Dockerfile-api


### PR DESCRIPTION
By default, when one job from a `matrix` fails, the others get cancelled. For linters, this is not what you want.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
