### PR TITLE
add -e flag to go-list command

### DIFF
--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -321,7 +321,15 @@ def test_resolve_gomod(
             assert mock_run.call_args_list[2][0][0] == ("go", "mod", "tidy")
 
     # when not vendoring, go list should be called with -mod readonly
-    assert mock_run.call_args_list[-2][0][0] == ["go", "list", "-mod", "readonly", "-find", "./..."]
+    assert mock_run.call_args_list[-2][0][0] == [
+        "go",
+        "list",
+        "-e",
+        "-mod",
+        "readonly",
+        "-find",
+        "./...",
+    ]
 
     for call in mock_run.call_args_list:
         env = call.kwargs["env"]
@@ -409,7 +417,7 @@ def test_resolve_gomod_vendor_dependencies(
 
     assert mock_run.call_args_list[0][0][0] == ("go", "mod", "vendor")
     # when vendoring, go list should be called without -mod readonly
-    assert mock_run.call_args_list[-2][0][0] == ["go", "list", "-find", "./..."]
+    assert mock_run.call_args_list[-2][0][0] == ["go", "list", "-e", "-find", "./..."]
     assert gomod["module"] == sample_package
     assert not gomod["module_deps"]
 


### PR DESCRIPTION
STONEBLD-631

Adding this flag to the go-list command prevents
erroneous packages from being printed to stderr
and causing the cachito request to fail needlessly

Tested locally with: https://github.com/openshift/sdn/commit/f2ff9949731708da53f8eb90dc5ff7ba7430a158

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- [x] Draft release notes are updated before merging
