### PR TITLE
Allow Yarn workspace dependencies by default (and many other fixes)

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -95,7 +95,6 @@ def _get_deps(package_lock_deps, file_deps_allowlist, name_to_deps=None, workspa
         # If there is npm workspace entry in dependencies of package-lock.json, skip it.
         elif version.startswith("file:") and _is_workspace_version(version, workspaces):
             log.info(f"The dependency '{name}' is npm workspace, skipping.")
-            continue
         # Note that a bundled dependency will not have the "resolved" key, but those are supported
         # since they are properly cached in the parent dependency in Nexus
         elif not info.get("bundled", False) and "resolved" not in info:

--- a/tests/integration/test_data/npm_packages.yaml
+++ b/tests/integration/test_data/npm_packages.yaml
@@ -453,6 +453,11 @@ workspaces:
         type: npm
         version: 2.0.0
       - dev: false
+        name: bar
+        replaces: null
+        type: npm
+        version: file:bar
+      - dev: false
         name: classnames
         replaces: null
         type: npm
@@ -468,6 +473,26 @@ workspaces:
         type: npm
         version: 5.0.3
       - dev: false
+        name: eggs
+        replaces: null
+        type: npm
+        version: file:eggs-packages/eggs
+      - dev: false
+        name: foo
+        replaces: null
+        type: npm
+        version: file:foo
+      - dev: false
+        name: not-baz
+        replaces: null
+        type: npm
+        version: file:baz
+      - dev: false
+        name: spam
+        replaces: null
+        type: npm
+        version: file:spam-packages/spam
+      - dev: false
         name: uuid
         replaces: null
         type: npm
@@ -479,6 +504,11 @@ workspaces:
           replaces: null
           type: npm
           version: 2.0.0
+        - dev: false
+          name: bar
+          replaces: null
+          type: npm
+          version: file:bar
         - dev: false
           name: classnames
           replaces: null
@@ -495,6 +525,26 @@ workspaces:
           type: npm
           version: 5.0.3
         - dev: false
+          name: eggs
+          replaces: null
+          type: npm
+          version: file:eggs-packages/eggs
+        - dev: false
+          name: foo
+          replaces: null
+          type: npm
+          version: file:foo
+        - dev: false
+          name: not-baz
+          replaces: null
+          type: npm
+          version: file:baz
+        - dev: false
+          name: spam
+          replaces: null
+          type: npm
+          version: file:spam-packages/spam
+        - dev: false
           name: uuid
           replaces: null
           type: npm
@@ -505,18 +555,48 @@ workspaces:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-workspaces@b4ec59868cb5667deb62930859762b107f23598c"
     dep_purls:
+      - "generic/bar?file%3Abar"
+      - "generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "generic/foo?file%3Afoo"
+      - "generic/not-baz?file%3Abaz"
+      - "generic/spam?file%3Aspam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
       - "pkg:npm/dateformat@5.0.3"
       - "pkg:npm/uuid@9.0.0"
     source_purls:
+      - "generic/bar?file%3Abar"
+      - "generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "generic/foo?file%3Afoo"
+      - "generic/not-baz?file%3Abaz"
+      - "generic/spam?file%3Aspam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
       - "pkg:npm/dateformat@5.0.3"
       - "pkg:npm/uuid@9.0.0"
   sbom:
+  - name: bar
+    type: library
+    version: file:bar
+    purl: generic/bar?file%3Abar
+  - name: eggs
+    type: library
+    version: file:eggs-packages/eggs
+    purl: generic/eggs?file%3Aeggs-packages%2Feggs
+  - name: foo
+    type: library
+    version: file:foo
+    purl: generic/foo?file%3Afoo
+  - name: not-baz
+    type: library
+    version: file:baz
+    purl: generic/not-baz?file%3Abaz
+  - name: spam
+    type: library
+    version: file:spam-packages/spam
+    purl: generic/spam?file%3Aspam-packages%2Fspam
   - name: npm_test
     type: library
     version: 1.1.0

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -381,14 +381,25 @@ def test_get_deps_allowlisted_file_dep():
 
 
 @pytest.mark.parametrize(
-    "package_lock_deps,workspaces,replacement,result",
+    "package_lock_deps,workspaces,allowlist,result",
     [
         ({}, [], set(), {}),
         (
             {"a": {"version": "file:a"}},
             ["a"],
             set(),
-            {},
+            {
+                "a": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "a",
+                        "version": "file:a",
+                        "version_in_nexus": None,
+                    },
+                ],
+            },
         ),
         (
             {
@@ -410,10 +421,46 @@ def test_get_deps_allowlisted_file_dep():
                         "version": "1.11.1",
                         "version_in_nexus": None,
                     },
-                ]
+                ],
+                "a": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "a",
+                        "version": "file:a",
+                        "version_in_nexus": None,
+                    },
+                ],
             },
         ),
-        ({"a": {"version": "file:a"}, "b": {"version": "file:b"}}, ["a", "b"], set(), {}),
+        (
+            {"a": {"version": "file:a"}, "b": {"version": "file:b"}},
+            ["a", "b"],
+            set(),
+            {
+                "a": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "a",
+                        "version": "file:a",
+                        "version_in_nexus": None,
+                    },
+                ],
+                "b": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "b",
+                        "version": "file:b",
+                        "version_in_nexus": None,
+                    },
+                ],
+            },
+        ),
         (
             {
                 "tslib": {
@@ -435,14 +482,17 @@ def test_get_deps_allowlisted_file_dep():
                         "version": "1.11.1",
                         "version_in_nexus": None,
                     },
-                ]
-            },
-        ),
-        (
-            {"a": {"version": "file:a"}, "b": {"version": "file:b"}},
-            ["a"],
-            {"b"},
-            {
+                ],
+                "a": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "a",
+                        "version": "file:a",
+                        "version_in_nexus": None,
+                    },
+                ],
                 "b": [
                     {
                         "bundled": False,
@@ -452,15 +502,40 @@ def test_get_deps_allowlisted_file_dep():
                         "version": "file:b",
                         "version_in_nexus": None,
                     },
-                ]
+                ],
+            },
+        ),
+        (
+            {"a": {"version": "file:a"}, "b": {"version": "file:b"}},
+            ["a"],
+            {"b"},
+            {
+                "a": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "a",
+                        "version": "file:a",
+                        "version_in_nexus": None,
+                    },
+                ],
+                "b": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "type": "npm",
+                        "name": "b",
+                        "version": "file:b",
+                        "version_in_nexus": None,
+                    },
+                ],
             },
         ),
     ],
 )
-def test_get_deps_worspaces(package_lock_deps, workspaces, replacement, result):
-    name_to_deps, replacements = npm._get_deps(
-        package_lock_deps, replacement, workspaces=workspaces
-    )
+def test_get_deps_worspaces(package_lock_deps, workspaces, allowlist, result):
+    name_to_deps, replacements = npm._get_deps(package_lock_deps, allowlist, workspaces=workspaces)
     assert name_to_deps == result
     assert replacements == []
 

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from cachito.errors import NexusError, UnsupportedFeature
+from cachito.errors import InvalidRepoStructure, NexusError
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers import yarn
 from cachito.workers.pkg_managers.general_js import JSDependency
@@ -298,7 +298,7 @@ def test_convert_to_nexus_hosted(
                 "subpackage@file:./subpath": {"version": "4.0.0"},
             },
             # allowlist
-            {"subpath"},
+            {"subpackage"},
             # expected_deps
             [
                 {
@@ -422,18 +422,16 @@ def test_get_deps(
     )
 
 
-@mock.patch("cachito.workers.pkg_managers.yarn._convert_to_nexus_hosted")
-def test_get_deps_disallowed_file_dep(mock_convert_hosted):
+def test_get_deps_disallowed_file_dep() -> None:
     package_json = {}
     yarn_lock = {
         "subpackage@file:./subpath": {"version": "1.0.0"},
     }
     allowlist = set()
 
-    err_msg = "The dependency ./subpath is hosted in an unsupported location"
-    mock_convert_hosted.side_effect = [UnsupportedFeature(err_msg)]
+    err_msg = "subpackage@file:./subpath is a 'file:' dependency."
 
-    with pytest.raises(UnsupportedFeature, match=err_msg):
+    with pytest.raises(InvalidRepoStructure, match=err_msg):
         yarn._get_deps(package_json, yarn_lock, allowlist)
 
 

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -323,6 +323,64 @@ def test_convert_to_nexus_hosted(
             # expected_convert_calls
             [],
         ),
+        # file dependency from a workspace
+        (
+            # package_json
+            {
+                "workspaces": ["subpath"],
+                "dependencies": {"subpackage": "file:./subpath"},
+            },
+            # yarn_lock
+            {
+                "subpackage@file:./subpath": {"version": "4.0.0"},
+            },
+            # allowlist
+            {},
+            # expected_deps
+            [
+                {
+                    "dev": False,
+                    "name": "subpackage",
+                    "version": "file:./subpath",
+                    "version_in_nexus": None,
+                    "bundled": False,
+                    "type": "yarn",
+                },
+            ],
+            # expected_replaced
+            [],
+            # expected_convert_calls
+            [],
+        ),
+        # file dependency from a workspace, different workspaces format
+        (
+            # package_json
+            {
+                "workspaces": {"packages": ["subpath"]},
+                "dependencies": {"subpackage": "file:./subpath"},
+            },
+            # yarn_lock
+            {
+                "subpackage@file:./subpath": {"version": "4.0.0"},
+            },
+            # allowlist
+            {},
+            # expected_deps
+            [
+                {
+                    "dev": False,
+                    "name": "subpackage",
+                    "version": "file:./subpath",
+                    "version_in_nexus": None,
+                    "bundled": False,
+                    "type": "yarn",
+                },
+            ],
+            # expected_replaced
+            [],
+            # expected_convert_calls
+            [],
+        ),
         # one http and one git dependency
         (
             # package_json


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] ~OpenAPI schema is updated (if applicable)~
- [ ] ~DB schema change has corresponding DB migration (if applicable)~
- [ ] ~README updated (if worker configuration changed, or if applicable)~
- [ ] Draft release notes are updated before merging
