### PR TITLE
Yarn workspaces black magic

### DIFF
--- a/tests/integration/test_data/yarn_packages.yaml
+++ b/tests/integration/test_data/yarn_packages.yaml
@@ -429,3 +429,196 @@ git_submodule:
     type: library
     version: 4.0.8
     purl: pkg:npm/type-detect@4.0.8
+# yarn package for testing workspaces
+# repo: The URL for the upstream git repository
+# ref: A git reference at the given git repository
+# expected_files: Expected source files <relative_path>: <file_URL>
+# response_expectations: Parts of the Cachito response to check
+# content_manifest: PURLs for image contents part
+workspaces:
+  repo: https://github.com/cachito-testing/cachito-yarn-workspaces.git
+  ref: 85e43d6b682d0e6420a6e4bcaf3072798d5254de
+  pkg_managers: ["yarn"]
+  expected_files:
+    app: https://github.com/cachito-testing/cachito-yarn-workspaces/tarball/85e43d6b682d0e6420a6e4bcaf3072798d5254de
+    deps/yarn/abbrev/abbrev-2.0.0.tgz: https://registry.npmjs.com/abbrev/-/abbrev-2.0.0.tgz
+    deps/yarn/classnames/classnames-2.3.2.tgz: https://registry.npmjs.com/classnames/-/classnames-2.3.2.tgz
+    deps/yarn/colors/colors-1.4.0.tgz: https://registry.npmjs.com/colors/-/colors-1.4.0.tgz
+    deps/yarn/dateformat/dateformat-5.0.3.tgz: https://registry.npmjs.com/dateformat/-/dateformat-5.0.3.tgz
+    deps/yarn/uuid/uuid-9.0.0.tgz: https://registry.npmjs.com/uuid/-/uuid-9.0.0.tgz
+  response_expectations:
+    dependencies:
+      - dev: false
+        name: abbrev
+        replaces: null
+        type: yarn
+        version: 2.0.0
+      - dev: false
+        name: bar
+        replaces: null
+        type: yarn
+        version: file:bar
+      - dev: false
+        name: classnames
+        replaces: null
+        type: yarn
+        version: 2.3.2
+      - dev: false
+        name: colors
+        replaces: null
+        type: yarn
+        version: 1.4.0
+      - dev: false
+        name: dateformat
+        replaces: null
+        type: yarn
+        version: 5.0.3
+      - dev: false
+        name: eggs
+        replaces: null
+        type: yarn
+        version: file:eggs-packages/eggs
+      - dev: false
+        name: foo
+        replaces: null
+        type: yarn
+        version: file:foo
+      - dev: false
+        name: not-baz
+        replaces: null
+        type: yarn
+        version: file:baz
+      - dev: false
+        name: spam
+        replaces: null
+        type: yarn
+        version: file:spam-packages/spam
+      - dev: false
+        name: uuid
+        replaces: null
+        type: yarn
+        version: 9.0.0
+    packages:
+      - dependencies:
+        - dev: false
+          name: abbrev
+          replaces: null
+          type: yarn
+          version: 2.0.0
+        - dev: false
+          name: bar
+          replaces: null
+          type: yarn
+          version: file:bar
+        - dev: false
+          name: classnames
+          replaces: null
+          type: yarn
+          version: 2.3.2
+        - dev: false
+          name: colors
+          replaces: null
+          type: yarn
+          version: 1.4.0
+        - dev: false
+          name: dateformat
+          replaces: null
+          type: yarn
+          version: 5.0.3
+        - dev: false
+          name: eggs
+          replaces: null
+          type: yarn
+          version: file:eggs-packages/eggs
+        - dev: false
+          name: foo
+          replaces: null
+          type: yarn
+          version: file:foo
+        - dev: false
+          name: not-baz
+          replaces: null
+          type: yarn
+          version: file:baz
+        - dev: false
+          name: spam
+          replaces: null
+          type: yarn
+          version: file:spam-packages/spam
+        - dev: false
+          name: uuid
+          replaces: null
+          type: yarn
+          version: 9.0.0
+        name: "npm_test"
+        type: "yarn"
+        version: "1.1.0"
+  content_manifest:
+  - purl: "pkg:github/cachito-testing/cachito-yarn-workspaces@85e43d6b682d0e6420a6e4bcaf3072798d5254de"
+    dep_purls:
+      - "generic/bar?file%3Abar"
+      - "generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "generic/foo?file%3Afoo"
+      - "generic/not-baz?file%3Abaz"
+      - "generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:npm/abbrev@2.0.0"
+      - "pkg:npm/classnames@2.3.2"
+      - "pkg:npm/colors@1.4.0"
+      - "pkg:npm/dateformat@5.0.3"
+      - "pkg:npm/uuid@9.0.0"
+    source_purls:
+      - "generic/bar?file%3Abar"
+      - "generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "generic/foo?file%3Afoo"
+      - "generic/not-baz?file%3Abaz"
+      - "generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:npm/abbrev@2.0.0"
+      - "pkg:npm/classnames@2.3.2"
+      - "pkg:npm/colors@1.4.0"
+      - "pkg:npm/dateformat@5.0.3"
+      - "pkg:npm/uuid@9.0.0"
+  sbom:
+  - name: bar
+    type: library
+    version: file:bar
+    purl: generic/bar?file%3Abar
+  - name: eggs
+    type: library
+    version: file:eggs-packages/eggs
+    purl: generic/eggs?file%3Aeggs-packages%2Feggs
+  - name: foo
+    type: library
+    version: file:foo
+    purl: generic/foo?file%3Afoo
+  - name: not-baz
+    type: library
+    version: file:baz
+    purl: generic/not-baz?file%3Abaz
+  - name: spam
+    type: library
+    version: file:spam-packages/spam
+    purl: generic/spam?file%3Aspam-packages%2Fspam
+  - name: npm_test
+    type: library
+    version: 1.1.0
+    purl: pkg:github/cachito-testing/cachito-yarn-workspaces@85e43d6b682d0e6420a6e4bcaf3072798d5254de
+  - name: abbrev
+    type: library
+    version: 2.0.0
+    purl: pkg:npm/abbrev@2.0.0
+  - name: classnames
+    type: library
+    version: 2.3.2
+    purl: pkg:npm/classnames@2.3.2
+  - name: colors
+    type: library
+    version: 1.4.0
+    purl: pkg:npm/colors@1.4.0
+  - name: dateformat
+    type: library
+    version: 5.0.3
+    purl: pkg:npm/dateformat@5.0.3
+  - name: uuid
+    type: library
+    version: 9.0.0
+    purl: pkg:npm/uuid@9.0.0

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -42,6 +42,7 @@ from . import utils
         ("yarn_packages", "without_deps"),
         ("yarn_packages", "with_deps"),
         ("yarn_packages", "git_submodule"),
+        ("yarn_packages", "workspaces"),
         ("rubygems_packages", "without_deps"),
         ("rubygems_packages", "with_deps"),
         ("rubygems_packages", "multiple"),


### PR DESCRIPTION
STONEBLD-692

Yarn allows the user to specify workspaces as dependencies using their
version rather than their path:

```json
{
  "workspaces": ["packages/*"],
  "dependencies": {
    "my-workspace": "^1.0.0"
  }
}
```

Yarn thinks it's a good idea not to include the dependencies that
resolve to a workspace in yarn.lock.

Likewise, it's possible that a workspace will not be specified as a
dependency at all, in which case yarn will (somewhat more reasonably)
also not include it in yarn.lock.

Implement workarounds for the parts of Cachito-yarn that this breaks:

* Don't fail in the non-dev dependency identification algorithm if some
  dependency doesn't exist in yarn.lock
* Detect workspaces on our own, report them as file: dependencies
* Identify the non-dev deps of workspaces as non-dev deps

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] ~OpenAPI schema is updated (if applicable)~
- [ ] ~DB schema change has corresponding DB migration (if applicable)~
- [ ] ~README updated (if worker configuration changed, or if applicable)~
- [ ] Draft release notes are updated before merging
