### PR TITLE
temporarily ignore bandit's warning about timeouts

### DIFF
--- a/cachito/workers/pkg_managers/general.py
+++ b/cachito/workers/pkg_managers/general.py
@@ -150,7 +150,9 @@ def download_binary_file(url, download_path, auth=None, insecure=False, chunk_si
     :raise NetworkError: If download failed
     """
     try:
-        resp = pkg_requests_session.get(url, stream=True, verify=not insecure, auth=auth)
+        resp = pkg_requests_session.get(
+            url, stream=True, verify=not insecure, auth=auth
+        )  # nosec request_without_timeout
         resp.raise_for_status()
     except requests.RequestException as e:
         raise NetworkError(f"Could not download {url}: {e}")

--- a/cachito/workers/pkg_managers/pip.py
+++ b/cachito/workers/pkg_managers/pip.py
@@ -1546,7 +1546,9 @@ def _download_pypi_package(requirement, pip_deps_dir, pypi_proxy_url, pypi_proxy
     # See https://www.python.org/dev/peps/pep-0503/
     package_url = f"{pypi_proxy_url.rstrip('/')}/simple/{canonicalize_name(package)}/"
     try:
-        pypi_resp = pkg_requests_session.get(package_url, auth=pypi_proxy_auth)
+        pypi_resp = pkg_requests_session.get(
+            package_url, auth=pypi_proxy_auth
+        )  # nosec request_without_timeout
         pypi_resp.raise_for_status()
     except requests.RequestException as e:
         raise NetworkError(f"PyPI query failed: {e}")


### PR DESCRIPTION
Same as https://github.com/containerbuildsystem/cachi2/commit/ea23dddd9379e918dffe72883907932250ea592a

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
