### PR TITLE
set 10 min network-timeout in .yarnrc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,9 +956,10 @@ After parsing, Cachito creates a yarn registry in an instance of Nexus it manage
 the dependencies discovered in the lock file. The registry is locked down so that no other
 dependencies can be added. The connection information is stored in an
 [.npmrc](https://docs.npmjs.com/configuring-npm/npmrc.html) file accessible at the
-`/api/v1/requests/<id>/configuration-files` API endpoint. There will be an empty
-[.yarnrc](https://classic.yarnpkg.com/en/docs/yarnrc) file in the same directory with the
-[.npmrc](https://docs.npmjs.com/configuring-npm/npmrc.html) file.
+`/api/v1/requests/<id>/configuration-files` API endpoint. Cachito also generates a
+[.yarnrc](https://classic.yarnpkg.com/en/docs/yarnrc) file in the same directory as the
+[.npmrc](https://docs.npmjs.com/configuring-npm/npmrc.html) file, overwriting any existing
+.yarnrc files if they exist.
 
 Cachito will produce a bundle that is downloadable at `/api/v1/requests/<id>/download`. This
 bundle will contain the application source code in the `app` directory and individual tarballs


### PR DESCRIPTION
STONEBLD-775

When either the disk or network are slow, yarn v1 is susceptible to network timeouts while installing packages.

Increase the timeout to 10 minutes.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
- [x] Draft release notes are updated before merging
