### PR TITLE
Add leftpad to yarn cached dependencies test

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -825,6 +825,11 @@ yarn_cached_deps:
         type: yarn
         version: 3.1.0
       - dev: false
+        name: leftpad
+        replaces: null
+        type: yarn
+        version: 0.0.1
+      - dev: false
         name: pathval
         replaces: null
         type: yarn
@@ -877,6 +882,11 @@ yarn_cached_deps:
           type: yarn
           version: 3.1.0
         - dev: false
+          name: leftpad
+          replaces: null
+          type: yarn
+          version: 0.0.1
+        - dev: false
           name: pathval
           replaces: null
           type: yarn
@@ -897,6 +907,7 @@ yarn_cached_deps:
     deps/yarn/deep-eql/deep-eql-3.0.1.tgz: https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz
     deps/yarn/external-fecha/fecha-4.2.0-external-sha1-f09ea0b8115b9733dddc88227086c73ba4ddc926.tgz: https://github.com/cachito-testing/test_files/raw/master/fecha-91680e4db1415fea33eac878cfd889c80a7b55c7.tgz
     deps/yarn/get-func-name/get-func-name-2.0.0.tgz: https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz
+    deps/yarn/leftpad/leftpad-0.0.1.tgz: https://registry.npmjs.org/leftpad/-/leftpad-0.0.1.tgz
     deps/yarn/pathval/pathval-1.1.1.tgz: https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz
     deps/yarn/type-detect/type-detect-4.0.8.tgz: https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz
   content_manifest:
@@ -910,6 +921,7 @@ yarn_cached_deps:
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
     - "pkg:npm/is-positive@3.1.0"
+    - "pkg:npm/leftpad@0.0.1"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
     source_purls:
@@ -921,6 +933,7 @@ yarn_cached_deps:
     - "pkg:npm/deep-eql@3.0.1"
     - "pkg:npm/get-func-name@2.0.0"
     - "pkg:npm/is-positive@3.1.0"
+    - "pkg:npm/leftpad@0.0.1"
     - "pkg:npm/pathval@1.1.1"
     - "pkg:npm/type-detect@4.0.8"
 rubygems_cached_deps:


### PR DESCRIPTION
The repository used for the test was updated in
https://github.com/cachito-testing/cachito-yarn-with-deps/commit/dd651df74599872e38bd719a554bb4638631e135

The cached dependencies test uses the latest commit.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
