### PR TITLE
Remove broken GH pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,7 @@ Run `cachito db upgrade --help` to get more info about additional arguments cons
 The documentation is generated from the [API specification](cachito/web/static/api_v1.yaml)
 written in the OpenAPI 3.0 format.
 
-It is available on [GitHub Pages](https://release-engineering.github.io/cachito) or Cachito's root
-URL.
+It is available on Cachito's root URL.
 
 ## Configuring Workers
 


### PR DESCRIPTION
We will no longer use github pages.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- n/a Draft release notes are updated before merging
