### PR TITLE
fix nexus Could not lock User prefs log spam

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,10 @@ services:
     image: sonatype/nexus3:3.45.0
     environment:
       # Enable the script API. This is disabled by default in 3.21.2+.
-      INSTALL4J_ADD_VM_PARAMS: -Dnexus.scripts.allowCreation=true -Dstorage.diskCache.diskFreeSpaceLimit=512
+      INSTALL4J_ADD_VM_PARAMS: >
+        -Dnexus.scripts.allowCreation=true
+        -Dstorage.diskCache.diskFreeSpaceLimit=512
+        -Djava.util.prefs.userRoot=/nexus-data/javaprefs
     volumes:
       # Use a local volume for nexus data (podman compatibility)
       - ./tmp/nexus-data:/nexus-data:z


### PR DESCRIPTION
Fixes a minor annoyance in the development environment nexus instance.

https://community.sonatype.com/t/problem-afer-upgrading-to-3-42-0-could-not-lock-user-prefs/9568

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- n/a Draft release notes are updated before merging
