### PR TITLE
allow npm registry deps from the yarn registry

### DIFF
--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -42,6 +42,7 @@ from cachito.workers.pkg_managers.general import (
 __all__ = [
     "download_dependencies",
     "get_dependencies",
+    "is_from_npm_registry",
     "parse_dependency",
     "finalize_nexus_for_js_request",
     "find_package_json",
@@ -55,6 +56,19 @@ __all__ = [
 ]
 
 log = logging.getLogger(__name__)
+
+
+NPM_REGISTRY_CNAMES = ("registry.npmjs.org", "registry.yarnpkg.com")
+
+
+def is_from_npm_registry(pkg_url):
+    """
+    Check if package is from the NPM registry (which is also the Yarn registry).
+
+    :param str pkg_url: url of the package, in yarn.lock this is always the "resolved" key
+    :rtype: bool
+    """
+    return urlparse(pkg_url).hostname in NPM_REGISTRY_CNAMES
 
 
 def parse_dependency(

--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -6,7 +6,6 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator, Optional, Self
-from urllib.parse import urlparse
 
 from cachito.errors import CachitoError, FileAccessError, ValidationError
 from cachito.workers.config import get_worker_config
@@ -14,6 +13,7 @@ from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general_js import (
     JSDependency,
     download_dependencies,
+    is_from_npm_registry,
     process_non_registry_dependency,
     vet_file_dependency,
 )
@@ -140,7 +140,7 @@ class Package:
     @property
     def is_registry_dep(self) -> bool:
         """Return True if this package is a registry dependency."""
-        return urlparse(self.resolved_url).hostname == "registry.npmjs.org"
+        return is_from_npm_registry(self.resolved_url)
 
     def get_dependency_names(self) -> list[str]:
         """Get the list of names of dependencies that this Package depends on.

--- a/cachito/workers/pkg_managers/yarn.py
+++ b/cachito/workers/pkg_managers/yarn.py
@@ -16,6 +16,7 @@ from cachito.workers.pkg_managers.general_js import (
     convert_hex_sha_to_npm,
     download_dependencies,
     get_yarn_component_info_from_non_hosted_nexus,
+    is_from_npm_registry,
     process_non_registry_dependency,
     vet_file_dependency,
 )
@@ -28,9 +29,6 @@ __all__ = [
 ]
 
 log = logging.getLogger(__name__)
-
-
-NPM_REGISTRY_CNAMES = ("registry.npmjs.org", "registry.yarnpkg.com")
 
 
 def get_yarn_proxy_repo_name(request_id):
@@ -245,7 +243,7 @@ def _get_deps(
 
         nexus_replacement = None
 
-        non_registry = not package.url or not _is_from_npm_registry(package.url)
+        non_registry = not package.url or not is_from_npm_registry(package.url)
         if non_registry:
             if source.startswith("file:"):
                 js_dep = JSDependency(package.name, source)
@@ -284,16 +282,6 @@ def _get_deps(
         }
 
     return list(deps_by_id.values()), nexus_replacements
-
-
-def _is_from_npm_registry(pkg_url):
-    """
-    Check if package is from the NPM registry (which is also the Yarn registry).
-
-    :param str pkg_url: url of the package, in yarn.lock this is always the "resolved" key
-    :rtype: bool
-    """
-    return urlparse(pkg_url).hostname in NPM_REGISTRY_CNAMES
 
 
 def _pick_strongest_crypto_hash(integrity_value):

--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -24,6 +24,18 @@ from cachito.workers.errors import NexusScriptError
 from cachito.workers.pkg_managers import general, general_js, npm
 
 
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz", True),
+        ("https://example.org/fecha.tar.gz", False),
+        ("https://registry.npmjs.org/chai/-/chai-4.2.0.tgz", True),
+    ],
+)
+def test_is_from_npm_registry(url, expected):
+    assert general_js.is_from_npm_registry(url) == expected
+
+
 @pytest.mark.parametrize("nexus_ca_cert_exists", (True, False))
 @pytest.mark.parametrize("pkg_manager", ["npm", "yarn"])
 @mock.patch("tempfile.TemporaryDirectory")

--- a/tests/test_workers/test_pkg_managers/test_yarn.py
+++ b/tests/test_workers/test_pkg_managers/test_yarn.py
@@ -71,18 +71,6 @@ def test_get_npm_proxy_username():
 
 
 @pytest.mark.parametrize(
-    "url, expected",
-    [
-        (REGISTRY_DEP_URL, True),
-        (HTTP_DEP_URL, False),
-        ("https://registry.npmjs.org/chai/-/chai-4.2.0.tgz", True),
-    ],
-)
-def test_is_from_npm_registry(url, expected):
-    assert yarn._is_from_npm_registry(url) == expected
-
-
-@pytest.mark.parametrize(
     "integrity_value, expected",
     [
         # only one option


### PR DESCRIPTION
In an npm request, consider dependencies from the yarn registry to be "registry" deps for the purpose of determining whether or not to upload to nexus.

During testing of https://github.com/containerbuildsystem/cachito/pull/857 I found a product with an npm package-lock.json file that has registry dependencies with "resolved" urls pointing to registry.yarnpkg.com. https://github.com/quay/quay/blob/1a96bd2f299f1199436a264f0d3afb8ff6f1ab60/package-lock.json

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~New code has type annotations~ not new code
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- n/a Draft release notes are updated before merging
