### PR TITLE
don't report npm devOptional as dev dependencies

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -115,7 +115,7 @@ class Package:
     @property
     def dev(self) -> bool:
         """Return True if this package is a dev dependency."""
-        return any(self._package_dict.get(key) for key in ("dev", "devOptional"))
+        return self._package_dict.get("dev", False)
 
     @property
     def is_link(self) -> bool:

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -498,6 +498,34 @@ class TestPackage:
         assert package.resolved_url == expected_resolved_url
 
     @pytest.mark.parametrize(
+        "package, is_dev",
+        [
+            (
+                Package("foo", {"dev": True}),
+                True,
+            ),
+            (
+                Package("foo", {"dev": False}),
+                False,
+            ),
+            (
+                Package("foo", {"devOptional": True}),
+                False,
+            ),
+            (
+                Package("foo", {"devOptional": False}),
+                False,
+            ),
+            (
+                Package("foo", {"dev": True, "optional": True}),
+                True,
+            ),
+        ],
+    )
+    def test_dev(self, package: Package, is_dev: bool) -> None:
+        assert package.dev == is_dev
+
+    @pytest.mark.parametrize(
         "package, expected_names",
         [
             pytest.param(


### PR DESCRIPTION
Whoops, I thought I had already fixed this. Last followup to https://github.com/containerbuildsystem/cachito/pull/857

Only report packages that are strictly part of the devDependencies tree as dev dependencies.
https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#packages

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- n/a Draft release notes are updated before merging
