### PR TITLE
Do download bundled deps if they are direct deps

### DIFF
--- a/cachito/workers/pkg_managers/npm.py
+++ b/cachito/workers/pkg_managers/npm.py
@@ -110,7 +110,13 @@ class Package:
     @property
     def bundled(self) -> bool:
         """Return True if this package is bundled."""
-        return any(self._package_dict.get(key) for key in ["bundled", "inBundle"])
+        return (
+            any(self._package_dict.get(key) for key in ["bundled", "inBundle"])
+            # In v2+ lockfiles, direct dependencies do have "inBundle": true if they are to be
+            # bundled. They will get bundled if the package is uploaded to the npm registry, but
+            # aren't bundled yet. These have a resolved url and shouldn't be considered bundled.
+            and "resolved" not in self._package_dict
+        )
 
     @property
     def dev(self) -> bool:

--- a/tests/test_workers/test_pkg_managers/test_npm.py
+++ b/tests/test_workers/test_pkg_managers/test_npm.py
@@ -1102,13 +1102,52 @@ def test_get_deps_non_registry_dep(
             },
             id="v2_packages",
         ),
+        pytest.param(
+            [
+                # direct bundled dep - should be downloaded, shouldn't be considered bundled
+                # npm init --yes
+                # npm add fecha --save-bundle
+                Package(
+                    "fecha",
+                    {
+                        "version": "4.2.3",
+                        "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+                        "inBundle": True,
+                    },
+                    path="node_modules/fecha",
+                ),
+                # indirect bundled dep, duplicate of the direct one
+                Package(
+                    "fecha",
+                    {
+                        "version": "4.2.3",
+                        # the result should be non-bundled and non-dev
+                        "inBundle": True,
+                        "dev": True,
+                    },
+                    path="node_modules/foo/node_modules/fecha",
+                ),
+            ],
+            {
+                "fecha": [
+                    {
+                        "bundled": False,
+                        "dev": False,
+                        "name": "fecha",
+                        "type": "npm",
+                        "version": "4.2.3",
+                        "version_in_nexus": None,
+                    },
+                ],
+            },
+            id="v2_packages_direct_bundled_dep",
+        ),
     ],
 )
 def test_get_deps_bundled_dep(
     packages: list[Package],
     expected_name_to_deps: dict[str, dict],
 ) -> None:
-
     package_lock = mock.Mock()
     package_lock.packages = packages
     name_to_deps, replacements = npm._get_deps(package_lock, set())


### PR DESCRIPTION
Npm marks to-be-bundled deps as bundled in lockfile v2+. We should consider those not bundled.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
N/A New code has type annotations
N/A OpenAPI schema is updated (if applicable)
N/A DB schema change has corresponding DB migration (if applicable)
N/A README updated (if worker configuration changed, or if applicable)
N/A Draft release notes are updated before merging
