### PR TITLE
Add docker.io as the default registry name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:9.6
+    image: docker.io/postgres:9.6
     environment:
       POSTGRES_USER: cachito
       POSTGRES_PASSWORD: cachito
@@ -9,7 +9,7 @@ services:
       POSTGRES_INITDB_ARGS: "--auth='ident' --auth='trust'"
 
   rabbitmq:
-    image: rabbitmq:3.11-management
+    image: docker.io/rabbitmq:3.11-management
     volumes:
       - ./docker/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:z
     ports:
@@ -17,7 +17,7 @@ services:
       - 8081:15672
 
   athens:
-    image: gomods/athens:v0.12.1
+    image: docker.io/gomods/athens:v0.12.1
     environment:
       ATHENS_DISK_STORAGE_ROOT: /var/lib/athens
       ATHENS_STORAGE_TYPE: disk
@@ -29,7 +29,7 @@ services:
       - 3000:3000
 
   nexus:
-    image: sonatype/nexus3:3.45.0
+    image: docker.io/sonatype/nexus3:3.45.0
     environment:
       # Enable the script API. This is disabled by default in 3.21.2+.
       INSTALL4J_ADD_VM_PARAMS: >


### PR DESCRIPTION
# Why

I'm using the `podman-compose` and, whenever I use `podman`, there's no default container registry.

Since all the default images expects `docker.io` as the default registry, I believe that makes sense to write it on the `docker-compose.yml` file.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] Draft release notes are updated before merging (I don't know what to do about this one here)
