### PR TITLE
Fix gomod cached dependencies integration test

### DIFF
--- a/tests/integration/test_data/cached_dependencies.yaml
+++ b/tests/integration/test_data/cached_dependencies.yaml
@@ -177,6 +177,10 @@ gomod_cached_deps:
         replaces: null
         type: "go-package"
         version: null
+      - name: "internal/coverage/rtcov"
+        replaces: null
+        type: "go-package"
+        version: null
       - name: "internal/cpu"
         replaces: null
         type: "go-package"
@@ -385,6 +389,10 @@ gomod_cached_deps:
       replaces: null
       type: "go-package"
       version: null
+    - name: "internal/coverage/rtcov"
+      replaces: null
+      type: "go-package"
+      version: null
     - name: "internal/cpu"
       replaces: null
       type: "go-package"
@@ -570,6 +578,7 @@ gomod_cached_deps:
     - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
     - "pkg:golang/internal%2Fabi"
     - "pkg:golang/internal%2Fbytealg"
+    - "pkg:golang/internal%2Fcoverage%2Frtcov"
     - "pkg:golang/internal%2Fcpu"
     - "pkg:golang/internal%2Ffmtsort"
     - "pkg:golang/internal%2Fgoarch"
@@ -650,6 +659,9 @@ gomod_cached_deps:
   - name: internal/bytealg
     type: library
     purl: pkg:golang/internal%2Fbytealg
+  - name: internal/coverage/rtcov
+    type: library
+    purl: pkg:golang/internal%2Fcoverage%2Frtcov
   - name: internal/cpu
     type: library
     purl: pkg:golang/internal%2Fcpu


### PR DESCRIPTION
The response expectations for this test needed to be updated as part of the Go 1.20 update, but this was not done in #886.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [n/a] Draft release notes are updated before merging
