### PR TITLE
Downgrade npm to 9.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ The table below shows the supported package managers and their support level in 
 Tool     | Version |
 ---      |---------|
 Go       | 1.20.7  |
-Npm      | 9.5.1   |
+Npm      | 9.5.0   |
 Node     | 18.16.1 |
 Pip      | 22.3.1  |
 Python   | 3.11.4  |

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -12,7 +12,7 @@ RUN dnf -y install \
     krb5-devel \
     libffi-devel \
     mercurial \
-    nodejs-npm \
+    nodejs-npm-9.5.0 \
     procps \
     python3-devel \
     python3-pip \


### PR DESCRIPTION
npm>=9.6.5 has a bug which causes `npm pack` to fail for git dependencies: https://github.com/npm/cli/issues/6723

The latest `nodejs-npm` available in the Fedora 38 repos is 9.6.7. Downgrade to the only older version still available, which is 9.5.0.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
