### PR TITLE
Download JS git dependencies more safely

### DIFF
--- a/tests/test_workers/test_pkg_managers/test_general_js.py
+++ b/tests/test_workers/test_pkg_managers/test_general_js.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import os.path
+import re
 import tarfile
 import textwrap
 from pathlib import Path
@@ -16,6 +17,7 @@ from cachito.errors import (
     InvalidFileFormat,
     InvalidRepoStructure,
     NexusError,
+    RepositoryAccessError,
     UnsupportedFeature,
 )
 from cachito.workers import nexus
@@ -524,31 +526,44 @@ def test_upload_non_registry_dependency(
 
 
 @mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.Git")
 @mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
-def test_upload_non_registry_dependency_invalid_prepare_script(mock_run_cmd, mock_td, tmpdir):
-    tarfile_path = os.path.join(tmpdir, "star-wars-5.0.0.tgz")
+def test_upload_non_registry_dependency_invalid_prepare_script(
+    mock_run_cmd: mock.Mock, mock_git: mock.Mock, mock_td: mock.Mock, tmp_path: Path
+) -> None:
+    dep_identifier = "github:LucasArts/StarWars#abcdef1234"
+    tarfile_path = tmp_path / "cachito-sources/github.com/LucasArts/StarWars/abcdef1234.git"
+    tarfile_path.parent.mkdir(parents=True)
+
     with tarfile.open(tarfile_path, "x:gz") as archive:
-        tar_info = tarfile.TarInfo("package/fair-warning.html")
+        tar_info = tarfile.TarInfo("app/fair-warning.html")
         content = "<h1>Je vais te détruire monsieur Solo!</h1>".encode("utf-8")
         tar_info.size = len(content)
         archive.addfile(tar_info, io.BytesIO(content))
 
-        tar_info = tarfile.TarInfo("package/package.json")
+        tar_info = tarfile.TarInfo("app/package.json")
         content = b'{"version": "5.0.0", "scripts": {"prepare": "rm -rf /"}}'
         tar_info.size = len(content)
         archive.addfile(tar_info, io.BytesIO(content))
 
-    mock_td.return_value.__enter__.return_value = str(tmpdir)
-    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+    mock_repo = mock_git.return_value
+    mock_repo.sources_dir.archive_path = tarfile_path
+
+    mock_td.return_value.__enter__.return_value = str(tmp_path)
 
     expected = (
-        "The dependency star-wars@5.0.0 is not supported because Cachito cannot execute the "
+        f"The dependency {dep_identifier} is not supported because Cachito cannot execute the "
         "following required scripts of Git dependencies: prepack, prepare"
     )
-    with pytest.raises(UnsupportedFeature, match=expected):
+    with pytest.raises(UnsupportedFeature, match=re.escape(expected)):
         general_js.upload_non_registry_dependency(
-            "star-wars@5.0.0", "-the-empire-strikes-back", verify_scripts=True
+            dep_identifier, "-the-empire-strikes-back", is_git=True
         )
+
+    mock_git.assert_called_once_with("https://git@github.com/LucasArts/StarWars.git", "abcdef1234")
+    mock_repo.fetch_source.assert_called_once_with(gitsubmodule=True)
+    # shouldn't call npm pack
+    mock_run_cmd.assert_not_called()
 
 
 @mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
@@ -591,6 +606,130 @@ def test_upload_non_registry_dependency_invalid_package_json(
     expected = "Could not process dependency star-wars@5.0.0: package.json is not valid JSON"
     with pytest.raises(FileAccessError, match=expected):
         general_js.upload_non_registry_dependency("star-wars@5.0.0", "-the-empire-strikes-back")
+
+
+@mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
+def test_fetch_external_dep_https(
+    mock_run_cmd: mock.Mock, mock_temp_dir: mock.Mock, tmp_path: Path
+) -> None:
+    dep_identifier = "https://github.com/LucasArts/StarWars/5.0.0.tar.gz"
+
+    mock_temp_dir.return_value.__enter__.return_value = str(tmp_path)
+    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+
+    archive_path = general_js._fetch_external_dep(
+        dep_identifier, is_git=False, temp_dir=str(tmp_path)
+    )
+    assert archive_path == str(tmp_path / "star-wars-5.0.0.tgz")
+
+    mock_run_cmd.assert_called_once_with(["npm", "pack", dep_identifier], mock.ANY, mock.ANY)
+
+
+@mock.patch("cachito.workers.pkg_managers.general_js.tempfile.TemporaryDirectory")
+@mock.patch("cachito.workers.pkg_managers.general_js.Git")
+@mock.patch("cachito.workers.pkg_managers.general_js.run_cmd")
+@pytest.mark.parametrize("both_clones_fail", [False, True])
+def test_fetch_external_dep_git(
+    mock_run_cmd: mock.Mock,
+    mock_git: mock.Mock,
+    mock_temp_dir: mock.Mock,
+    both_clones_fail: bool,
+    tmp_path: Path,
+) -> None:
+    dep_identifier = "github:LucasArts/StarWars#abcdef1234"
+
+    mock_temp_dir.return_value.__enter__.return_value = str(tmp_path)
+
+    tarfile_path = tmp_path / "cachito-sources/github.com/LucasArts/StarWars/abcdef1234.tar.gz"
+    tarfile_path.parent.mkdir(parents=True)
+
+    https_repo = mock.Mock()
+    ssh_repo = mock.Mock()
+    mock_git.side_effect = [https_repo, ssh_repo]
+
+    https_repo.fetch_source.side_effect = RepositoryAccessError()
+    if both_clones_fail:
+        ssh_repo.fetch_source.side_effect = RepositoryAccessError()
+
+    https_repo.sources_dir.archive_path = tarfile_path
+    ssh_repo.sources_dir.archive_path = tarfile_path
+
+    with tarfile.open(tarfile_path, "x:gz") as archive:
+        tar_info = tarfile.TarInfo("app/package.json")
+        content = b'{"version": "5.0.0"}'
+        tar_info.size = len(content)
+        archive.addfile(tar_info, io.BytesIO(content))
+
+    mock_run_cmd.return_value = "star-wars-5.0.0.tgz\n"
+
+    if both_clones_fail:
+        with pytest.raises(RepositoryAccessError):
+            general_js._fetch_external_dep(dep_identifier, is_git=True, temp_dir=str(tmp_path))
+    else:
+        archive_path = general_js._fetch_external_dep(
+            dep_identifier, is_git=True, temp_dir=str(tmp_path)
+        )
+        assert archive_path == str(tmp_path / "star-wars-5.0.0.tgz")
+        # test that we extracted the archive into the expected location
+        assert tmp_path.joinpath("app/package.json").read_text() == '{"version": "5.0.0"}'
+        mock_run_cmd.assert_called_once_with(
+            ["npm", "pack", f"file:{tmp_path / 'app'}"], mock.ANY, mock.ANY
+        )
+
+    mock_git.assert_has_calls(
+        [
+            mock.call("https://git@github.com/LucasArts/StarWars.git", "abcdef1234"),
+            mock.call("ssh://git@github.com/LucasArts/StarWars.git", "abcdef1234"),
+        ]
+    )
+    https_repo.fetch_source.assert_called_once_with(gitsubmodule=True)
+    ssh_repo.fetch_source.assert_called_once_with(gitsubmodule=True)
+
+
+@pytest.mark.parametrize(
+    "npm_git_url, expect_git_urls",
+    [
+        (
+            "github:LucasArts/StarWars",
+            [
+                "https://git@github.com/LucasArts/StarWars.git",
+                "ssh://git@github.com/LucasArts/StarWars.git",
+            ],
+        ),
+        (
+            "gitlab:LucasArts/StarWars",
+            [
+                "https://git@gitlab.com/LucasArts/StarWars.git",
+                "ssh://git@gitlab.com/LucasArts/StarWars.git",
+            ],
+        ),
+        (
+            "bitbucket:LucasArts/StarWars",
+            [
+                "https://git@bitbucket.org/LucasArts/StarWars.git",
+                "ssh://git@bitbucket.org/LucasArts/StarWars.git",
+            ],
+        ),
+        (
+            "git+ssh://git@github.com/LucasArts/StarWars.git",
+            [
+                "https://git@github.com/LucasArts/StarWars.git",
+                "ssh://git@github.com/LucasArts/StarWars.git",
+            ],
+        ),
+        (
+            "git+https://git@github.com/LucasArts/StarWars.git",
+            ["https://git@github.com/LucasArts/StarWars.git"],
+        ),
+        (
+            "git://git@github.com/LucasArts/StarWars.git",
+            ["git://git@github.com/LucasArts/StarWars.git"],
+        ),
+    ],
+)
+def test_get_clonable_urls(npm_git_url: str, expect_git_urls: list[str]) -> None:
+    assert general_js._get_clonable_urls(npm_git_url) == expect_git_urls
 
 
 @pytest.mark.parametrize("exists", (False, True))


### PR DESCRIPTION
What Cachito did previously:
- set NPM_CONFIG_IGNORE_SCRIPTS=true
- npm pack the git dependency
- check for dangerous scripts in package.json

What Cachito does now:
- git clone the git dependency
- check for dangerous scripts in package.json
- set NPM_CONFIG_IGNORE_SCRIPTS=true
- npm pack the cloned directory

The npm pack command is opaque to us, it is hard to prove its safety with respect to dangerous scripts. Cloning manually is much safer.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] ~OpenAPI schema is updated (if applicable)~
- [ ] ~DB schema change has corresponding DB migration (if applicable)~
- [ ] ~README updated (if worker configuration changed, or if applicable)~
- [x] Draft release notes are updated before merging
