### PR TITLE
Fix "library stubs not installed" mypy error

### DIFF
--- a/cachito/workers/requests.py
+++ b/cachito/workers/requests.py
@@ -3,7 +3,7 @@ import logging
 
 import requests
 import requests_kerberos
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 from cachito.workers.config import get_worker_config
 


### PR DESCRIPTION
After merging https://github.com/containerbuildsystem/cachito/pull/920, mypy started to fail with:

'Library stubs not installed for "requests.packages.urllib3.util.retry"'

Looking at the requests source code, it seems that urllib3 is imported ad-hoc in the packages module, so changing the import to urllib3 directly solved the issue.

I still don't know what caused it originally, since the merge request was just a bump to the 'packaging' library.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
