### PR TITLE
Fix flaky test for request metrics

### DIFF
--- a/tests/integration/test_request_metrics.py
+++ b/tests/integration/test_request_metrics.py
@@ -54,7 +54,7 @@ def test_get_request_metrics_summary(api_client):
         "server_errors",
         "total",
     }.difference(summary)
-    assert summary["total"] == total
+    assert summary["total"] >= total
     assert 0 < summary["duration_50"] <= summary["duration_95"]
     assert summary["duration_avg"] > 0
     assert summary["time_in_queue_avg"] > 0


### PR DESCRIPTION
test_get_request_metrics_summary fails often with checking the number of total processed requests.
I believe it is due to additional user request(s) finished in the time window we are checking for our 3 test requests.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [n/a] Draft release notes are updated before merging
