### PR TITLE
Change dependabot PR frequency for minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      patch-and-minor-updates:
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
The intent is to to lower the amount and frequency of PRs opened by Dependabot in the repository. Major updates are still being kept in separate PRs, since they usually require a more thorough review.

This PR is inspired by https://github.com/containerbuildsystem/cachi2/pull/368, but I'm proposing using a single group for both patch and minor updates. 

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [n/a] Draft release notes are updated before merging
