### PR TITLE
Github actions: perform an apt-get update before installing packages

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -20,8 +20,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install required packages
       run: |
-        sudo apt-get install -y \
-          libkrb5-dev
+        sudo apt-get update
+        sudo apt-get install -y libkrb5-dev
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -75,8 +75,8 @@ jobs:
         fetch-depth: 0
     - name: Install required packages
       run: |
-        sudo apt-get install -y \
-          libkrb5-dev
+        sudo apt-get update
+        sudo apt-get install -y libkrb5-dev
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -131,8 +131,8 @@ jobs:
         fetch-depth: 0
     - name: Install required packages
       run: |
-        sudo apt-get install -y \
-          libkrb5-dev
+        sudo apt-get update
+        sudo apt-get install -y libkrb5-dev
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This corrects the error of getting a 404 when trying to fetch packages from the Ubuntu registry:

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/k/krb5/libgssrpc4_1.19.2-2ubuntu0.2_amd64.deb
404  Not Found [IP: 52.147.219.192 80]
```

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
