### PR TITLE
Add new API endpoint requests/latest

### DIFF
--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -341,6 +341,52 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RequestUpdate'
+  "/requests/latest":
+    get:
+      operationId: cachito.web.api_v1.get_latest_request
+      summary: Get the latest request for a repo/ref
+      description: Return the latest request for a specified repo_name and ref
+      parameters:
+      - name: repo_name
+        required: true
+        in: query
+        description: >
+          The namespaced repository name (namespace/name). The domain and protocol/scheme
+          must not be present in this param (e.g. https://github.com/my-org/my-repo translates
+          to my-org/my-repo).
+        schema:
+          type: string
+          minLength: 3
+          maxLength: 200
+          pattern: '^.*\/[\w.-]+$'
+          example: release-engineering/retrodep
+      - name: ref
+        required: true
+        in: query
+        description: The git reference
+        schema:
+          type: string
+          minLength: 40
+          maxLength: 40
+          pattern: '^[a-f0-9]{40}$'
+          example: bc9767a71ede6e0084ae4a9e01dcd8b81c30b741
+      responses:
+        "200":
+          description: The requested Cachito request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Request"
+        "404":
+          description: The request wasn't found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: The requested resource was not found
   "/requests/{request_id}/configuration-files":
     get:
       operationId: cachito.web.api_v1.get_request_config_files

--- a/tests/integration/test_get_latest_request.py
+++ b/tests/integration/test_get_latest_request.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Any
+
+from cachito.common.utils import get_repo_name
+
+from . import utils
+
+
+def test_get_latest_request(api_client: utils.Client, test_env: dict[str, Any]) -> None:
+    """
+    Generates requests and ensures that the requests/latest endpoint returns the most recent one.
+
+    For each package in "various_packages", a request and a duplicate request are generated.
+    After all requests have been completed for all packages, the requests/latest endpoint is
+    queried for each repo_name/ref combination. The request_id of the final duplicate request
+    for each package should match what is returned by the latest endpoint.
+    """
+    latest_created_request_ids = {}
+    repeat_count = 2
+
+    # Generate the requests
+    for pkg_manager, package in test_env["various_packages"].items():
+        repo_name = get_repo_name(package["repo"])
+        for _ in range(repeat_count):
+            initial_response = api_client.create_new_request(
+                payload={
+                    "repo": package["repo"],
+                    "ref": package["ref"],
+                    "pkg_managers": [pkg_manager],
+                },
+            )
+            completed_response = api_client.wait_for_complete_request(initial_response)
+            utils.assert_properly_completed_response(completed_response)
+            latest_created_request_ids[(repo_name, package["ref"])] = completed_response.data["id"]
+
+    # Check that the latest is the latest
+    for package in test_env["various_packages"].values():
+        repo_name = get_repo_name(package["repo"])
+        latest_request = api_client.fetch_latest_request(
+            repo_name=repo_name, ref=package["ref"]
+        ).json()
+
+        assert {
+            "id",
+            "repo",
+            "ref",
+            "updated",
+        }.issubset(latest_request), "Required fields missing from returned Request"
+        assert "configuration_files" not in latest_request, "A verbose Request was returned"
+        assert (
+            latest_created_request_ids[(repo_name, package["ref"])] == latest_request["id"]
+        ), f"id={latest_request['id']} is not the latest request for {(repo_name, package['ref'])}"

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -123,6 +123,18 @@ class Client:
 
         return Response({"items": all_items}, None, resp.status_code)
 
+    def fetch_latest_request(self, **params) -> requests.Response:
+        """
+        Fetch the latest request for a repo/ref from the Cachito API.
+
+        :param dict query_params: Request parameters and values (repo_name, ref)
+        :return: Object that contains response from the Cachito API
+        :rtype: Response
+        """
+        resp = self.requests_session.get(f"{self._cachito_api_url}/requests/latest", params=params)
+        resp.raise_for_status()
+        return resp
+
     def fetch_content_manifest(self, request_id):
         """
         Fetch a contest manifest by request_id from the Cachito API.


### PR DESCRIPTION
The requests/latest endpoint will return the most recent request for a given repo_name and git ref

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
