### PR TITLE
add missing colorama dependency for isort

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,10 @@ commands =
 
 [testenv:isort]
 skip_install = true
+# Remove colorama after https://github.com/PyCQA/isort/issues/2211 is released
 deps =
     isort[colors]
+    colorama
 commands =
     isort --check --diff --color cachito tests
 


### PR DESCRIPTION
isort[colors] recently removed their dependency on colorama. Add it back until isort releases their fix to restore the dependency.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [n/a] Draft release notes are updated before merging
