### PR TITLE
fetch updated tags when updating source archive

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -208,7 +208,7 @@ class Git(SCM):
             try:
                 # The reference must be specified to handle commits which are not part
                 # of a branch.
-                repo.remote().fetch(refspec=self.ref)
+                repo.remote().fetch(refspec=self.ref, tags=True, force=True)
 
             except Exception as ex:
                 log.exception(


### PR DESCRIPTION
When creating a new source archive from an existing source archive, cachito should fetch updated tags from the origin repository. If this is not done, no new tags will ever be added to any source archive after the first source archive for a given repository. This breaks version resolution for some projects.

Using --force when fetching with tags appears to be necessary for the case where a tag is moved in the origin repository. If this happens, git exits with an error on the fetch.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
N/A OpenAPI schema is updated (if applicable)
N/A DB schema change has corresponding DB migration (if applicable)
N/A README updated (if worker configuration changed, or if applicable)
- [x] Draft release notes are updated before merging
