### PR TITLE
STONEBLD-2103: cachito: extend blobless cloning to submodules

### DIFF
--- a/cachito/workers/scm.py
+++ b/cachito/workers/scm.py
@@ -294,7 +294,7 @@ class Git(SCM):
                                      update the git submodules.
         """
         log.debug(f"Git submodules for the requested repo are: {repo.submodules}")
-        cmd = ["git", "submodule", "update", "--init"]
+        cmd = ["git", "submodule", "update", "--init", "--filter=blob:none"]
         try:
             run_cmd(cmd, {"cwd": repo.working_dir, "check": True})
         except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
Extend the blobless cloning to submodules. This is done by adding the "--filter=blob:none" option to the "git submodule update" command. This will help in situations where cachito responds with a gateway timeout when bundles of very large size (>2GB) are downloaded.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
N/A New code has type annotations
N/A OpenAPI schema is updated (if applicable)
N/A DB schema change has corresponding DB migration (if applicable)
N/A README updated (if worker configuration changed, or if applicable)
- [x] Draft release notes are updated before merging
