### PR TITLE
when determining archive age, fall-back to updated time

### DIFF
--- a/cachito/workers/prune_archives.py
+++ b/cachito/workers/prune_archives.py
@@ -117,11 +117,19 @@ def _resolve_source_archive(parsed_archive: _ParsedArchive) -> Optional[_Resolve
         log.debug("Archive %s could not be resolved via the API.", parsed_archive.path)
         return None
 
+    request_age = latest_request.get("created") or latest_request.get("updated")
+    if request_age is None:
+        # This should be impossible
+        log.debug(
+            "Unable to determine the age of %s with latest request_id=%s",
+            parsed_archive.path,
+            latest_request["id"],
+        )
+        return None
+
     return _ResolvedArchive(
         parsed_archive.path,
-        datetime.strptime(latest_request["created"], "%Y-%m-%dT%H:%M:%S.%f").replace(
-            tzinfo=timezone.utc
-        ),
+        datetime.strptime(request_age, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=timezone.utc),
         latest_request["id"],
     )
 


### PR DESCRIPTION
The created field in a request can potentially be None. If so, fall back to using the updated field in order to determine the age of a request.

Something I knew about and missed :sweat:. The created field was added later, but the updated field has been there since the beginning and should be approximately the same.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
