### PR TITLE
Add preliminary Go 1.21 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ The table below shows the supported package managers and their support level in 
 
 Tool     | Version |
 ---      |---------|
-Go       | 1.20.7  |
+Go*      | 1.20.7, 1.21.0  |
 Npm      | 9.5.0   |
 Node     | 18.16.1 |
 Pip      | 22.3.1  |
@@ -761,6 +761,12 @@ Bundler* | 2.x     |
 * Cachito does not use the Ruby runtime (no ruby is interpreted from `Gemfile`s). 
   The processing of Gemfile.lock files is handled by
   [gemlock-parser](https://github.com/containerbuildsystem/gemlock-parser).
+* Starting with Go 1.21 Go changed the meaning of the `go` directive in `go.mod` file slightly and
+  made the constraint stricter in that the line now denotes the **minimum required** version of Go
+  instead of a suggested version of Go. If a project recommending an older version of Go is
+  processed with Go >=1.21 it might happen (based on other dependencies) that its own required
+  version of Go will be bumped to 1.21+, hence dirtying the git repo - to prevent this cachito
+  uses two releases of Go SDK concurrently.
 
 ### gomod
 

--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -541,6 +541,9 @@ paths:
                 GOSUMDB:
                   value: off
                   kind: literal
+                GOTOOLCHAIN:
+                  value: local
+                  kind: literal
         "404":
           description: The request wasn't found
           content:
@@ -1221,6 +1224,9 @@ components:
               kind: path
             GOSUMDB:
               value: off
+              kind: literal
+            GOTOOLCHAIN:
+              value: local
               kind: literal
         state:
           $ref: "#/components/schemas/RequestState"

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -29,7 +29,10 @@ class Config(object):
     cachito_archives_minimum_age_days = 365
     cachito_auth_type: Optional[str] = None
     cachito_default_environment_variables = {
-        "gomod": {"GOSUMDB": {"value": "off", "kind": "literal"}},
+        "gomod": {
+            "GOSUMDB": {"value": "off", "kind": "literal"},
+            "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
+        },
         "npm": {
             "CHROMEDRIVER_SKIP_DOWNLOAD": {"value": "true", "kind": "literal"},
             "CYPRESS_INSTALL_BINARY": {"value": "0", "kind": "literal"},
@@ -161,6 +164,7 @@ class TestingConfig(DevelopmentConfig):
         "gomod": {
             "GO111MODULE": {"value": "on", "kind": "literal"},
             "GOSUMDB": {"value": "off", "kind": "literal"},
+            "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
         },
         "npm": {
             "CHROMEDRIVER_SKIP_DOWNLOAD": {"value": "true", "kind": "literal"},

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -312,6 +312,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
             "GOPROXY": f"{athens_url}|{athens_url}",
             "PATH": os.environ.get("PATH", ""),
             "GOMODCACHE": "{}/pkg/mod".format(temp_dir),
+            "GOTOOLCHAIN": "local",
         }
         if "cgo-disable" in request.get("flags", []):
             env["CGO_ENABLED"] = "0"

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -141,9 +141,11 @@ class Go:
         return self._run(cmd, **params)
 
     @property
-    def version(self) -> pkgver.Version:  # type: ignore
+    def version(self) -> pkgver.Version:
         """Version of the Go toolchain as a packaging.version.Version object."""
-        pass
+        if not self._version:
+            self._version = pkgver.Version(self.release[2:])
+        return self._version
 
     @property
     def release(self) -> str:

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -141,6 +141,14 @@ class Go:
         """Release name of the Go Toolchain, e.g. go1.20 ."""
         pass
 
+    def _run(self, cmd: list[str], **kwargs: Any) -> str:
+        try:
+            log.debug(f"Running '{cmd}'")
+            return run_cmd(cmd, kwargs)
+        except CachitoCalledProcessError as e:
+            rc = e.retcode
+            raise GoModError(f"Go execution failed: `{' '.join(cmd)}` failed with {rc=}") from e
+
 
 @tracer.start_as_current_span("run_download_cmd")
 def run_download_cmd(cmd: Iterable[str], params: Dict[str, str]) -> str:

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -18,6 +18,10 @@ import pydantic
 import semver
 from opentelemetry import trace
 
+# if a namespace alias isn't used, flake8 starts complaining whenever version.Version is used:
+# 'local variable 'version' defined in enclosing scope on line N referenced before assignment'
+from packaging import version as pkgver
+
 from cachito.errors import (
     GoModError,
     InvalidFileFormat,
@@ -89,6 +93,53 @@ class GoPackage(_GolangModel):
     standard: bool = False
     module: Optional[GoModule]
     deps: list[str] = []
+
+
+class Go:
+    """High level wrapper over the 'go' CLI command.
+
+    Provides convenient methods to download project dependencies, alternative toolchains,
+    parses various Go files, etc.
+    """
+
+    def __init__(
+        self,
+        binary: Union[str, os.PathLike[str]] = "go",
+        release: Optional[str] = None,
+    ) -> None:
+        """Initialize the Go toolchain wrapper.
+
+        :param binary: path-like string to the Go binary or direct command (in PATH)
+        :param release: Go release version string, e.g. go1.20, go1.21.10
+        :returns: a callable instance
+        """
+        # run_cmd will take care of checking any bogus passed in 'binary'
+        self._bin = str(binary)
+        self._release = release
+
+        self._version: Optional[pkgver.Version] = None
+
+    def __call__(
+        self, cmd: list[str], params: Optional[dict] = None, retry: bool = False
+    ) -> str:  # type: ignore
+        """Run a Go command using the underlying toolchain, same as running GoToolchain()().
+
+        :param cmd: Go CLI options
+        :param params: additional subprocess arguments, e.g. 'env'
+        :param retry: whether the command should be retried on failure (e.g. network actions)
+        :returs: Go command's output
+        """
+        pass
+
+    @property
+    def version(self) -> pkgver.Version:  # type: ignore
+        """Version of the Go toolchain as a packaging.version.Version object."""
+        pass
+
+    @property
+    def release(self) -> str:  # type: ignore
+        """Release name of the Go Toolchain, e.g. go1.20 ."""
+        pass
 
 
 @tracer.start_as_current_span("run_download_cmd")

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -1071,3 +1071,22 @@ def get_golang_version(module_name, git_path, commit_sha, update_tags=False, sub
     return _get_golang_pseudo_version(
         commit, module_major_version=module_major_version, subpath=subpath
     )
+
+
+def _get_gomod_version(source_dir: Path) -> Optional[str]:
+    """Return the required/recommended version of Go from go.mod.
+
+    We need to extract the desired version of Go ourselves as older versions of Go might fail
+    due to e.g. unknown keywords or unexpected format of the version (yes, Go always performs
+    validation of go.mod).
+
+    If we cannot extract a version from the 'go' line, we return None, leaving it up to the caller
+    to decide what to do next.
+    """
+    go_mod = source_dir / "go.mod"
+    with open(go_mod) as f:
+        reg = re.compile(r"^\s*go\s+(?P<ver>\d\.\d+(:?.\d+)?)\s*$")
+        for line in f:
+            if match := re.match(reg, line):
+                return match.group("ver")
+    return None

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -11,7 +11,6 @@ from cachito.errors import (
     InvalidRequestData,
     UnsupportedFeature,
 )
-from cachito.workers import run_cmd
 from cachito.workers.config import get_worker_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import update_request_env_vars
@@ -129,9 +128,6 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
         a non-single go module path
     :raises GoModError: if failed to fetch gomod dependencies
     """
-    version_output = run_cmd(["go", "version"], {})
-    log.info(f"Go version: {version_output.strip()}")
-
     config = get_worker_config()
     if package_configs is None:
         package_configs = []

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -27,6 +27,18 @@ RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
     && pip3 install . --no-deps --no-cache-dir \
     && rm -rf .git
 
+# Install a newer version of Go fixed at 1.21.0 (along with the base 1.20.X):
+#   - install Go's official shim
+#   - let the shim download the actual Go SDK (the download forces the output parent dir to $HOME)
+#   - move the SDK to a host local install system-wide location
+#   - remove the shim as it forces and expects the SDK to be used from $HOME
+#   - clean any build artifacts Go creates as part of the process.
+RUN go install 'golang.org/dl/go1.21.0@latest' && \
+    "$HOME/go/bin/go1.21.0" download && \
+    mkdir /usr/local/go && \
+    mv "$HOME/sdk/go1.21.0" /usr/local/go && \
+    rm -rf "$HOME/go" "$HOME/.cache/go-build/"
+
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/directory-hash/ca-bundle.crt
 # Use the system CA bundle for native SSL calls from celery (python)

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -33,6 +33,14 @@ def get_mocked_data(filepath: Union[str, Path]) -> str:
     return gomod_mocks.joinpath(filepath).read_text()
 
 
+@pytest.fixture
+def go_mod_file(tmp_path: Path, request: pytest.FixtureRequest) -> None:
+    output_file = tmp_path / "go.mod"
+
+    with open(output_file, "w") as f:
+        f.write(request.param)
+
+
 RETRODEP_PRE_REPLACE = "github.com/release-engineering/retrodep/v2"
 RETRODEP_POST_REPLACE = "github.com/cachito-testing/retrodep/v2"
 
@@ -1249,6 +1257,24 @@ def test_run_download_cmd_failure(mock_sleep, mock_run, mock_worker_config, capl
     assert "Backing off run_go(...) for 4.0s" in caplog.text
     assert "Backing off run_go(...) for 8.0s" in caplog.text
     assert "Giving up run_go(...) after 5 tries" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "go_mod_file, go_mod_version",
+    [("go 1.21", "1.21"), ("    go    1.21.4    ", "1.21.4")],
+    indirect=["go_mod_file"],
+)
+def test_get_gomod_version(tmp_path: Path, go_mod_file: Path, go_mod_version: str) -> None:
+    assert gomod._get_gomod_version(tmp_path) == go_mod_version
+
+
+@pytest.mark.parametrize(
+    "go_mod_file",
+    [pytest.param(_, id=_) for _ in ["go1.21", "go 1.21.0.100", "1.21", "go 1.21 foo"]],
+    indirect=True,
+)
+def test_get_gomod_version_fail(tmp_path: Path, go_mod_file: Path) -> None:
+    assert gomod._get_gomod_version(tmp_path) is None
 
 
 class TestGo:

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -114,6 +114,7 @@ def test_fetch_gomod_source(
     env_vars = {
         "GO111MODULE": {"value": "on", "kind": "literal"},
         "GOSUMDB": {"value": "off", "kind": "literal"},
+        "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
     }
     sample_env_vars.update(env_vars)
 


### PR DESCRIPTION
This PR just deals with the necessary bits to get projects building with 1.21. Proper 1.21 support including support for the toolchain will be proposed in the future.

This PR is based on https://github.com/containerbuildsystem/cachi2/pull/427 from which much of the code was ported with one notable exception -  as proposed cachito won't download the 1.20 toolchain locally like cachi2 does in case it's missing. The reason for that is that only the container environment use case is considered and hence the worker images will have 1.20 baked into them.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- [x] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
