### PR TITLE
Fix go module not in root repo

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -285,7 +285,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
     """
     Resolve and fetch gomod dependencies for given app source archive.
 
-    :param str app_source_path: the full path to the application source code
+    :param Path app_source_path: the full path to the application source code
     :param dict request: the Cachito request this is for
     :param list dep_replacements: dependency replacements with the keys "name" and "version"; this
         results in a series of `go mod edit -replace` commands
@@ -319,7 +319,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
 
         run_params = {"env": env, "cwd": app_source_path}
 
-        go = _select_go_toolchain(git_dir_path)
+        go = _select_go_toolchain(app_source_path)
 
         # Collect all the dependency names that are being replaced to later report which
         # dependencies were replaced
@@ -383,8 +383,8 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
             update_tags=True,
             subpath=(
                 None
-                if app_source_path == str(git_dir_path)
-                else app_source_path.replace(f"{git_dir_path}/", "")
+                if app_source_path == git_dir_path
+                else str(app_source_path).replace(f"{git_dir_path}/", "")
             ),
         )
         main_module = {
@@ -662,7 +662,7 @@ def _vet_local_deps(
     dependencies: List[dict],
     module_name: str,
     allowed_patterns: List[str],
-    app_source_path: str,
+    app_source_path: Path,
     git_dir_path: str,
 ) -> None:
     """
@@ -693,11 +693,13 @@ def _vet_local_deps(
             )
 
 
-def _validate_local_dependency_path(app_source_path: str, git_dir_path: str, dep_path: str) -> None:
+def _validate_local_dependency_path(
+    app_source_path: Path, git_dir_path: str, dep_path: str
+) -> None:
     """
     Validate that the local dependency path is not outside the repository.
 
-    :param str app_source_path: the full path to the application source code
+    :param Path app_source_path: the full path to the application source code
     :param str git_dir_path: the full path to the git repository
     :param str dep_path: the relative path for local replacements (the dep version)
     :raise ValidationError: if the local dependency path is invalid
@@ -1049,7 +1051,7 @@ def _get_gomod_version(source_dir: Path) -> Optional[str]:
     If we cannot extract a version from the 'go' line, we return None, leaving it up to the caller
     to decide what to do next.
     """
-    go_mod = source_dir / "go.mod"
+    go_mod = source_dir.joinpath("go.mod")
     with open(go_mod) as f:
         reg = re.compile(r"^\s*go\s+(?P<ver>\d\.\d+(:?.\d+)?)\s*$")
         for line in f:

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -166,6 +166,7 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
         "GOCACHE": {"value": "deps/gomod", "kind": "path"},
         "GOPATH": {"value": "deps/gomod", "kind": "path"},
         "GOMODCACHE": {"value": "deps/gomod/pkg/mod", "kind": "path"},
+        "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
     }
     env_vars.update(config.cachito_default_environment_variables.get("gomod", {}))
     update_request_env_vars(request_id, env_vars)
@@ -182,7 +183,7 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
             f'Fetching the gomod dependencies at the "{subpath}" directory',
         )
         request = get_request(request_id)
-        gomod_source_path = str(bundle_dir.app_subpath(subpath).source_dir)
+        gomod_source_path = Path(bundle_dir.app_subpath(subpath).source_dir)
         try:
             gomod = resolve_gomod(
                 gomod_source_path, request, dep_replacements, bundle_dir.source_dir

--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -3561,3 +3561,912 @@ with_local_replacements_in_parent_dir:
   - name: unsafe
     type: library
     purl: pkg:golang/unsafe
+multiple_modules:
+  repo: https://github.com/cachito-testing/gomod-multiple-modules.git
+  ref: f9c648b9bf9839613dcffcf98e3f2abaa9e6e39a
+  pkg_managers: ["gomod"]
+  packages:
+    gomod: [ { "path": "eggs-module" }, { "path": "spam-module" } ]
+  response_expectations:
+    dependencies:
+      - name: bytes
+        replaces: null
+        type: go-package
+        version: null
+      - name: errors
+        replaces: null
+        type: go-package
+        version: null
+      - name: fmt
+        replaces: null
+        type: go-package
+        version: null
+      - name: golang.org/x/text/internal/tag
+        replaces: null
+        type: go-package
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: golang.org/x/text/language
+        replaces: null
+        type: go-package
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: internal/abi
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/bytealg
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/coverage/rtcov
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/cpu
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/fmtsort
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/goarch
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/goexperiment
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/goos
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/itoa
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/oserror
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/poll
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/race
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/reflectlite
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/safefilepath
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/syscall/execenv
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/syscall/unix
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/testlog
+        replaces: null
+        type: go-package
+        version: null
+      - name: internal/unsafeheader
+        replaces: null
+        type: go-package
+        version: null
+      - name: io
+        replaces: null
+        type: go-package
+        version: null
+      - name: io/fs
+        replaces: null
+        type: go-package
+        version: null
+      - name: math
+        replaces: null
+        type: go-package
+        version: null
+      - name: math/bits
+        replaces: null
+        type: go-package
+        version: null
+      - name: os
+        replaces: null
+        type: go-package
+        version: null
+      - name: path
+        replaces: null
+        type: go-package
+        version: null
+      - name: reflect
+        replaces: null
+        type: go-package
+        version: null
+      - name: rsc.io/quote
+        replaces: null
+        type: go-package
+        version: v1.5.1
+      - name: rsc.io/quote
+        replaces: null
+        type: go-package
+        version: v1.5.2
+      - name: rsc.io/sampler
+        replaces: null
+        type: go-package
+        version: v1.3.0
+      - name: runtime
+        replaces: null
+        type: go-package
+        version: null
+      - name: runtime/internal/atomic
+        replaces: null
+        type: go-package
+        version: null
+      - name: runtime/internal/math
+        replaces: null
+        type: go-package
+        version: null
+      - name: runtime/internal/sys
+        replaces: null
+        type: go-package
+        version: null
+      - name: runtime/internal/syscall
+        replaces: null
+        type: go-package
+        version: null
+      - name: sort
+        replaces: null
+        type: go-package
+        version: null
+      - name: strconv
+        replaces: null
+        type: go-package
+        version: null
+      - name: strings
+        replaces: null
+        type: go-package
+        version: null
+      - name: sync
+        replaces: null
+        type: go-package
+        version: null
+      - name: sync/atomic
+        replaces: null
+        type: go-package
+        version: null
+      - name: syscall
+        replaces: null
+        type: go-package
+        version: null
+      - name: time
+        replaces: null
+        type: go-package
+        version: null
+      - name: unicode
+        replaces: null
+        type: go-package
+        version: null
+      - name: unicode/utf8
+        replaces: null
+        type: go-package
+        version: null
+      - name: unsafe
+        replaces: null
+        type: go-package
+        version: null
+      - name: golang.org/x/text
+        replaces: null
+        type: gomod
+        version: v0.0.0-20170915032832-14c0d48ead0c
+      - name: rsc.io/quote
+        replaces: null
+        type: gomod
+        version: v1.5.1
+      - name: rsc.io/quote
+        replaces: null
+        type: gomod
+        version: v1.5.2
+      - name: rsc.io/sampler
+        replaces: null
+        type: gomod
+        version: v1.3.0
+    packages:
+      - dependencies:
+        - name: bytes
+          replaces: null
+          type: go-package
+          version: null
+        - name: errors
+          replaces: null
+          type: go-package
+          version: null
+        - name: fmt
+          replaces: null
+          type: go-package
+          version: null
+        - name: golang.org/x/text/internal/tag
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: golang.org/x/text/language
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: internal/abi
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/bytealg
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/coverage/rtcov
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/cpu
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/fmtsort
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/goarch
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/goexperiment
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/goos
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/itoa
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/oserror
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/poll
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/race
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/syscall/execenv
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/syscall/unix
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/testlog
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/unsafeheader
+          replaces: null
+          type: go-package
+          version: null
+        - name: io
+          replaces: null
+          type: go-package
+          version: null
+        - name: io/fs
+          replaces: null
+          type: go-package
+          version: null
+        - name: math
+          replaces: null
+          type: go-package
+          version: null
+        - name: math/bits
+          replaces: null
+          type: go-package
+          version: null
+        - name: os
+          replaces: null
+          type: go-package
+          version: null
+        - name: path
+          replaces: null
+          type: go-package
+          version: null
+        - name: reflect
+          replaces: null
+          type: go-package
+          version: null
+        - name: rsc.io/quote
+          replaces: null
+          type: go-package
+          version: v1.5.1
+        - name: rsc.io/sampler
+          replaces: null
+          type: go-package
+          version: v1.3.0
+        - name: runtime
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/atomic
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/math
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/sys
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/syscall
+          replaces: null
+          type: go-package
+          version: null
+        - name: sort
+          replaces: null
+          type: go-package
+          version: null
+        - name: strconv
+          replaces: null
+          type: go-package
+          version: null
+        - name: strings
+          replaces: null
+          type: go-package
+          version: null
+        - name: sync
+          replaces: null
+          type: go-package
+          version: null
+        - name: sync/atomic
+          replaces: null
+          type: go-package
+          version: null
+        - name: syscall
+          replaces: null
+          type: go-package
+          version: null
+        - name: time
+          replaces: null
+          type: go-package
+          version: null
+        - name: unicode
+          replaces: null
+          type: go-package
+          version: null
+        - name: unicode/utf8
+          replaces: null
+          type: go-package
+          version: null
+        - name: unsafe
+          replaces: null
+          type: go-package
+          version: null
+        name: github.com/cachito-testing/gomod-multiple-modules/eggs-module
+        path: eggs-module
+        type: go-package
+        version: v0.0.0-20240219150512-f9c648b9bf98
+      - dependencies:
+        - name: bytes
+          replaces: null
+          type: go-package
+          version: null
+        - name: errors
+          replaces: null
+          type: go-package
+          version: null
+        - name: fmt
+          replaces: null
+          type: go-package
+          version: null
+        - name: golang.org/x/text/internal/tag
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: golang.org/x/text/language
+          replaces: null
+          type: go-package
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: internal/abi
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/bytealg
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/coverage/rtcov
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/cpu
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/fmtsort
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/goarch
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/goexperiment
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/goos
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/itoa
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/oserror
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/poll
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/race
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/reflectlite
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/safefilepath
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/syscall/execenv
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/syscall/unix
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/testlog
+          replaces: null
+          type: go-package
+          version: null
+        - name: internal/unsafeheader
+          replaces: null
+          type: go-package
+          version: null
+        - name: io
+          replaces: null
+          type: go-package
+          version: null
+        - name: io/fs
+          replaces: null
+          type: go-package
+          version: null
+        - name: math
+          replaces: null
+          type: go-package
+          version: null
+        - name: math/bits
+          replaces: null
+          type: go-package
+          version: null
+        - name: os
+          replaces: null
+          type: go-package
+          version: null
+        - name: path
+          replaces: null
+          type: go-package
+          version: null
+        - name: reflect
+          replaces: null
+          type: go-package
+          version: null
+        - name: rsc.io/quote
+          replaces: null
+          type: go-package
+          version: v1.5.2
+        - name: rsc.io/sampler
+          replaces: null
+          type: go-package
+          version: v1.3.0
+        - name: runtime
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/atomic
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/math
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/sys
+          replaces: null
+          type: go-package
+          version: null
+        - name: runtime/internal/syscall
+          replaces: null
+          type: go-package
+          version: null
+        - name: sort
+          replaces: null
+          type: go-package
+          version: null
+        - name: strconv
+          replaces: null
+          type: go-package
+          version: null
+        - name: strings
+          replaces: null
+          type: go-package
+          version: null
+        - name: sync
+          replaces: null
+          type: go-package
+          version: null
+        - name: sync/atomic
+          replaces: null
+          type: go-package
+          version: null
+        - name: syscall
+          replaces: null
+          type: go-package
+          version: null
+        - name: time
+          replaces: null
+          type: go-package
+          version: null
+        - name: unicode
+          replaces: null
+          type: go-package
+          version: null
+        - name: unicode/utf8
+          replaces: null
+          type: go-package
+          version: null
+        - name: unsafe
+          replaces: null
+          type: go-package
+          version: null
+        name: github.com/cachito-testing/gomod-multiple-modules/spam-module
+        path: spam-module
+        type: go-package
+        version: v1.2.1-0.20240219150512-f9c648b9bf98
+      - dependencies:
+        - name: golang.org/x/text
+          replaces: null
+          type: gomod
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: rsc.io/quote
+          replaces: null
+          type: gomod
+          version: v1.5.1
+        - name: rsc.io/sampler
+          replaces: null
+          type: gomod
+          version: v1.3.0
+        name: github.com/cachito-testing/gomod-multiple-modules/eggs-module
+        path: eggs-module
+        type: gomod
+        version: v0.0.0-20240219150512-f9c648b9bf98
+      - dependencies:
+        - name: golang.org/x/text
+          replaces: null
+          type: gomod
+          version: v0.0.0-20170915032832-14c0d48ead0c
+        - name: rsc.io/quote
+          replaces: null
+          type: gomod
+          version: v1.5.2
+        - name: rsc.io/sampler
+          replaces: null
+          type: gomod
+          version: v1.3.0
+        name: github.com/cachito-testing/gomod-multiple-modules/spam-module
+        path: spam-module
+        type: gomod
+        version: v1.2.1-0.20240219150512-f9c648b9bf98
+  expected_files:
+    app: https://github.com/cachito-testing/gomod-multiple-modules/tarball/f9c648b9bf9839613dcffcf98e3f2abaa9e6e39a
+    deps/gomod/pkg/mod/cache/download/rsc.io/quote/@v/v1.5.2.zip: https://github.com/cachito-testing/test_files/raw/master/test_gomod_with_deps_quote.tar.gz
+  content_manifest:
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-multiple-modules%2Feggs-module@v0.0.0-20240219150512-f9c648b9bf98"
+    dep_purls:
+    - "pkg:golang/bytes"
+    - "pkg:golang/errors"
+    - "pkg:golang/fmt"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/internal%2Fabi"
+    - "pkg:golang/internal%2Fbytealg"
+    - "pkg:golang/internal%2Fcoverage%2Frtcov"
+    - "pkg:golang/internal%2Fcpu"
+    - "pkg:golang/internal%2Ffmtsort"
+    - "pkg:golang/internal%2Fgoarch"
+    - "pkg:golang/internal%2Fgoexperiment"
+    - "pkg:golang/internal%2Fgoos"
+    - "pkg:golang/internal%2Fitoa"
+    - "pkg:golang/internal%2Foserror"
+    - "pkg:golang/internal%2Fpoll"
+    - "pkg:golang/internal%2Frace"
+    - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
+    - "pkg:golang/internal%2Fsyscall%2Fexecenv"
+    - "pkg:golang/internal%2Fsyscall%2Funix"
+    - "pkg:golang/internal%2Ftestlog"
+    - "pkg:golang/internal%2Funsafeheader"
+    - "pkg:golang/io"
+    - "pkg:golang/io%2Ffs"
+    - "pkg:golang/math"
+    - "pkg:golang/math%2Fbits"
+    - "pkg:golang/os"
+    - "pkg:golang/path"
+    - "pkg:golang/reflect"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.1"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+    - "pkg:golang/runtime"
+    - "pkg:golang/runtime%2Finternal%2Fatomic"
+    - "pkg:golang/runtime%2Finternal%2Fmath"
+    - "pkg:golang/runtime%2Finternal%2Fsys"
+    - "pkg:golang/runtime%2Finternal%2Fsyscall"
+    - "pkg:golang/sort"
+    - "pkg:golang/strconv"
+    - "pkg:golang/strings"
+    - "pkg:golang/sync"
+    - "pkg:golang/sync%2Fatomic"
+    - "pkg:golang/syscall"
+    - "pkg:golang/time"
+    - "pkg:golang/unicode"
+    - "pkg:golang/unicode%2Futf8"
+    - "pkg:golang/unsafe"
+    source_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.1"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+  - purl: "pkg:golang/github.com%2Fcachito-testing%2Fgomod-multiple-modules%2Fspam-module@v1.2.1-0.20240219150512-f9c648b9bf98"
+    dep_purls:
+    - "pkg:golang/bytes"
+    - "pkg:golang/errors"
+    - "pkg:golang/fmt"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/internal%2Fabi"
+    - "pkg:golang/internal%2Fbytealg"
+    - "pkg:golang/internal%2Fcoverage%2Frtcov"
+    - "pkg:golang/internal%2Fcpu"
+    - "pkg:golang/internal%2Ffmtsort"
+    - "pkg:golang/internal%2Fgoarch"
+    - "pkg:golang/internal%2Fgoexperiment"
+    - "pkg:golang/internal%2Fgoos"
+    - "pkg:golang/internal%2Fitoa"
+    - "pkg:golang/internal%2Foserror"
+    - "pkg:golang/internal%2Fpoll"
+    - "pkg:golang/internal%2Frace"
+    - "pkg:golang/internal%2Freflectlite"
+    - "pkg:golang/internal%2Fsafefilepath"
+    - "pkg:golang/internal%2Fsyscall%2Fexecenv"
+    - "pkg:golang/internal%2Fsyscall%2Funix"
+    - "pkg:golang/internal%2Ftestlog"
+    - "pkg:golang/internal%2Funsafeheader"
+    - "pkg:golang/io"
+    - "pkg:golang/io%2Ffs"
+    - "pkg:golang/math"
+    - "pkg:golang/math%2Fbits"
+    - "pkg:golang/os"
+    - "pkg:golang/path"
+    - "pkg:golang/reflect"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+    - "pkg:golang/runtime"
+    - "pkg:golang/runtime%2Finternal%2Fatomic"
+    - "pkg:golang/runtime%2Finternal%2Fmath"
+    - "pkg:golang/runtime%2Finternal%2Fsys"
+    - "pkg:golang/runtime%2Finternal%2Fsyscall"
+    - "pkg:golang/sort"
+    - "pkg:golang/strconv"
+    - "pkg:golang/strings"
+    - "pkg:golang/sync"
+    - "pkg:golang/sync%2Fatomic"
+    - "pkg:golang/syscall"
+    - "pkg:golang/time"
+    - "pkg:golang/unicode"
+    - "pkg:golang/unicode%2Futf8"
+    - "pkg:golang/unsafe"
+    source_purls:
+    - "pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c"
+    - "pkg:golang/rsc.io%2Fquote@v1.5.2"
+    - "pkg:golang/rsc.io%2Fsampler@v1.3.0"
+  sbom:
+  - name: bytes
+    type: library
+    purl: pkg:golang/bytes
+  - name: errors
+    type: library
+    purl: pkg:golang/errors
+  - name: fmt
+    type: library
+    purl: pkg:golang/fmt
+  - name: github.com/cachito-testing/gomod-multiple-modules/eggs-module
+    type: library
+    version: v0.0.0-20240219150512-f9c648b9bf98
+    purl: pkg:golang/github.com%2Fcachito-testing%2Fgomod-multiple-modules%2Feggs-module@v0.0.0-20240219150512-f9c648b9bf98
+  - name: github.com/cachito-testing/gomod-multiple-modules/spam-module
+    type: library
+    version: v1.2.1-0.20240219150512-f9c648b9bf98
+    purl: pkg:golang/github.com%2Fcachito-testing%2Fgomod-multiple-modules%2Fspam-module@v1.2.1-0.20240219150512-f9c648b9bf98
+  - name: golang.org/x/text/internal/tag
+    type: library
+    version: v0.0.0-20170915032832-14c0d48ead0c
+    purl: pkg:golang/golang.org%2Fx%2Ftext%2Finternal%2Ftag@v0.0.0-20170915032832-14c0d48ead0c
+  - name: golang.org/x/text/language
+    type: library
+    version: v0.0.0-20170915032832-14c0d48ead0c
+    purl: pkg:golang/golang.org%2Fx%2Ftext%2Flanguage@v0.0.0-20170915032832-14c0d48ead0c
+  - name: golang.org/x/text
+    type: library
+    version: v0.0.0-20170915032832-14c0d48ead0c
+    purl: pkg:golang/golang.org%2Fx%2Ftext@v0.0.0-20170915032832-14c0d48ead0c
+  - name: internal/abi
+    type: library
+    purl: pkg:golang/internal%2Fabi
+  - name: internal/bytealg
+    type: library
+    purl: pkg:golang/internal%2Fbytealg
+  - name: internal/coverage/rtcov
+    type: library
+    purl: pkg:golang/internal%2Fcoverage%2Frtcov
+  - name: internal/cpu
+    type: library
+    purl: pkg:golang/internal%2Fcpu
+  - name: internal/fmtsort
+    type: library
+    purl: pkg:golang/internal%2Ffmtsort
+  - name: internal/goarch
+    type: library
+    purl: pkg:golang/internal%2Fgoarch
+  - name: internal/goexperiment
+    type: library
+    purl: pkg:golang/internal%2Fgoexperiment
+  - name: internal/goos
+    type: library
+    purl: pkg:golang/internal%2Fgoos
+  - name: internal/itoa
+    type: library
+    purl: pkg:golang/internal%2Fitoa
+  - name: internal/oserror
+    type: library
+    purl: pkg:golang/internal%2Foserror
+  - name: internal/poll
+    type: library
+    purl: pkg:golang/internal%2Fpoll
+  - name: internal/race
+    type: library
+    purl: pkg:golang/internal%2Frace
+  - name: internal/reflectlite
+    type: library
+    purl: pkg:golang/internal%2Freflectlite
+  - name: internal/safefilepath
+    type: library
+    purl: pkg:golang/internal%2Fsafefilepath
+  - name: internal/syscall/execenv
+    type: library
+    purl: pkg:golang/internal%2Fsyscall%2Fexecenv
+  - name: internal/syscall/unix
+    type: library
+    purl: pkg:golang/internal%2Fsyscall%2Funix
+  - name: internal/testlog
+    type: library
+    purl: pkg:golang/internal%2Ftestlog
+  - name: internal/unsafeheader
+    type: library
+    purl: pkg:golang/internal%2Funsafeheader
+  - name: io
+    type: library
+    purl: pkg:golang/io
+  - name: io/fs
+    type: library
+    purl: pkg:golang/io%2Ffs
+  - name: math
+    type: library
+    purl: pkg:golang/math
+  - name: math/bits
+    type: library
+    purl: pkg:golang/math%2Fbits
+  - name: os
+    type: library
+    purl: pkg:golang/os
+  - name: path
+    type: library
+    purl: pkg:golang/path
+  - name: reflect
+    type: library
+    purl: pkg:golang/reflect
+  - name: rsc.io/quote
+    type: library
+    version: v1.5.1
+    purl: pkg:golang/rsc.io%2Fquote@v1.5.1
+  - name: rsc.io/quote
+    type: library
+    version: v1.5.2
+    purl: pkg:golang/rsc.io%2Fquote@v1.5.2
+  - name: rsc.io/sampler
+    type: library
+    version: v1.3.0
+    purl: pkg:golang/rsc.io%2Fsampler@v1.3.0
+  - name: runtime
+    type: library
+    purl: pkg:golang/runtime
+  - name: runtime/internal/atomic
+    type: library
+    purl: pkg:golang/runtime%2Finternal%2Fatomic
+  - name: runtime/internal/math
+    type: library
+    purl: pkg:golang/runtime%2Finternal%2Fmath
+  - name: runtime/internal/sys
+    type: library
+    purl: pkg:golang/runtime%2Finternal%2Fsys
+  - name: runtime/internal/syscall
+    type: library
+    purl: pkg:golang/runtime%2Finternal%2Fsyscall
+  - name: sort
+    type: library
+    purl: pkg:golang/sort
+  - name: strconv
+    type: library
+    purl: pkg:golang/strconv
+  - name: strings
+    type: library
+    purl: pkg:golang/strings
+  - name: sync
+    type: library
+    purl: pkg:golang/sync
+  - name: sync/atomic
+    type: library
+    purl: pkg:golang/sync%2Fatomic
+  - name: syscall
+    type: library
+    purl: pkg:golang/syscall
+  - name: time
+    type: library
+    purl: pkg:golang/time
+  - name: unicode
+    type: library
+    purl: pkg:golang/unicode
+  - name: unicode/utf8
+    type: library
+    purl: pkg:golang/unicode%2Futf8
+  - name: unsafe
+    type: library
+    purl: pkg:golang/unsafe

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -27,6 +27,7 @@ from . import utils
         ("gomod_packages", "symlink_loop"),
         ("gomod_packages", "without_pkg_manager"),
         ("gomod_packages", "with_local_replacements_in_parent_dir"),
+        ("gomod_packages", "multiple_modules"),
         ("gomod_vendor_check", "correct_vendor"),
         ("gomod_vendor_check", "no_vendor"),
         ("npm_packages", "without_deps_v1_lockfile"),

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -26,19 +26,19 @@ from cachito.workers.tasks import gomod
             None,
             True,
             None,
-            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": "./"}},
+            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": Path("./")}},
         ),
         (
             None,
             False,
             None,
-            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": "./"}},
+            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": Path("./")}},
         ),
         (
             [{"name": "github.com/pkg/errors", "type": "gomod", "version": "v0.8.1"}],
             True,
             None,
-            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": "./"}},
+            {"present": {".": True}, "relpath": {".": "./go.mod"}, "sourcedir": {".": Path("./")}},
         ),
         (
             None,
@@ -47,7 +47,7 @@ from cachito.workers.tasks import gomod
             {
                 "present": {"bar": True, "foo": True},
                 "relpath": {"bar": "./bar/go.mod", "foo": "./foo/go.mod"},
-                "sourcedir": {"bar": "./bar/", "foo": "./foo/"},
+                "sourcedir": {"bar": Path("./bar/"), "foo": Path("./foo/")},
             },
         ),
         (
@@ -57,7 +57,7 @@ from cachito.workers.tasks import gomod
             {
                 "present": {".": True, "foo": True},
                 "relpath": {".": "./go.mod", "foo": "./foo/go.mod"},
-                "sourcedir": {".": "./", "foo": "./foo/"},
+                "sourcedir": {".": Path("./"), "foo": Path("./foo/")},
             },
         ),
         (
@@ -67,7 +67,7 @@ from cachito.workers.tasks import gomod
             {
                 "present": {".": True, "foo": True},
                 "relpath": {".": "./go.mod", "foo": "./foo/go.mod"},
-                "sourcedir": {".": "./", "foo": "./foo/"},
+                "sourcedir": {".": Path("./"), "foo": Path("./foo/")},
             },
         ),
     ),
@@ -191,7 +191,7 @@ def test_fetch_gomod_source(
 
     gomod_calls = [
         mock.call(
-            str(mock_bundle_dir().app_subpath(path).source_dir),
+            mock_bundle_dir().app_subpath(path).source_dir,
             mock_request,
             dep_replacements,
             mock_bundle_dir().source_dir,


### PR DESCRIPTION
A bug was introduced in the 1.17 release. We were relying on the git repo path instead of the actual module path, and this caused an issue when the module is not in the repo's root.

 JIRA: STONEBLD-2191

integration test repo: https://github.com/cachito-testing/gomod-multiple-modules/tree/no_root_go_mod

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a]] DB schema change has corresponding DB migration (if applicable)
- [n/a]] README updated (if worker configuration changed, or if applicable)
- [n/a]] Draft release notes are updated before merging
