### PR TITLE
switch secondary go install to go 1.20

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -27,16 +27,16 @@ RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
     && pip3 install . --no-deps --no-cache-dir \
     && rm -rf .git
 
-# Install a newer version of Go fixed at 1.21.0 (along with the base 1.20.X):
+# Install an older version of Go fixed at 1.20 (along with the base >= 1.21):
 #   - install Go's official shim
 #   - let the shim download the actual Go SDK (the download forces the output parent dir to $HOME)
 #   - move the SDK to a host local install system-wide location
 #   - remove the shim as it forces and expects the SDK to be used from $HOME
 #   - clean any build artifacts Go creates as part of the process.
-RUN go install 'golang.org/dl/go1.21.0@latest' && \
-    "$HOME/go/bin/go1.21.0" download && \
+RUN go install 'golang.org/dl/go1.20@latest' && \
+    "$HOME/go/bin/go1.20" download && \
     mkdir /usr/local/go && \
-    mv "$HOME/sdk/go1.21.0" /usr/local/go && \
+    mv "$HOME/sdk/go1.20" /usr/local/go && \
     rm -rf "$HOME/go" "$HOME/.cache/go-build/"
 
 # Use the system CA bundle for the requests library


### PR DESCRIPTION
The latest version of the go package available in fedora-38 has moved from go1.20 to go1.21.

Since we require both go >= 1.21 and go1.20 to be
installed in the image, switch the secondary install from go1.21 to go1.20.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] ~Code coverage from testing does not decrease and new code is covered~
- [ ] ~New code has type annotations~
- [ ] ~OpenAPI schema is updated (if applicable)~
- [ ] ~DB schema change has corresponding DB migration (if applicable)~
- [ ] ~README updated (if worker configuration changed, or if applicable)~
- [ ] Draft release notes are updated before merging
