### PR TITLE
add pkg scheme to npm generic file PURLs

### DIFF
--- a/cachito/web/purl.py
+++ b/cachito/web/purl.py
@@ -66,7 +66,7 @@ def _to_purl_npm(package):
     has_authority = match.group("has_authority")
     if protocol == "file":
         qualifier = urllib.parse.quote(package.version, safe="")
-        return f"generic/{purl_name}?{qualifier}"
+        return f"pkg:generic/{purl_name}?{qualifier}"
     elif not has_authority:
         # github:namespace/name#ref or gitlab:ns1/ns2/name#ref
         match_forge = re.match(r"(?P<namespace>.+)/(?P<name>[^#/]+)#(?P<version>.+)$", suffix)

--- a/cachito/web/purl.py
+++ b/cachito/web/purl.py
@@ -65,8 +65,9 @@ def _to_purl_npm(package):
     suffix = match.group("suffix")
     has_authority = match.group("has_authority")
     if protocol == "file":
-        qualifier = urllib.parse.quote(package.version, safe="")
-        return f"pkg:generic/{purl_name}?{qualifier}"
+        path = urllib.parse.urlparse(package.version).path
+        quoted_path = urllib.parse.quote(path, safe="")
+        return f"pkg:generic/{purl_name}?file={quoted_path}"
     elif not has_authority:
         # github:namespace/name#ref or gitlab:ns1/ns2/name#ref
         match_forge = re.match(r"(?P<namespace>.+)/(?P<name>[^#/]+)#(?P<version>.+)$", suffix)

--- a/tests/integration/test_data/npm_packages.yaml
+++ b/tests/integration/test_data/npm_packages.yaml
@@ -782,22 +782,22 @@ workspaces:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-workspaces@b4ec59868cb5667deb62930859762b107f23598c"
     dep_purls:
-      - "pkg:generic/bar?file%3Abar"
-      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "pkg:generic/foo?file%3Afoo"
-      - "pkg:generic/not-baz?file%3Abaz"
-      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file=bar"
+      - "pkg:generic/eggs?file=eggs-packages%2Feggs"
+      - "pkg:generic/foo?file=foo"
+      - "pkg:generic/not-baz?file=baz"
+      - "pkg:generic/spam?file=spam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
       - "pkg:npm/dateformat@5.0.3"
       - "pkg:npm/uuid@9.0.0"
     source_purls:
-      - "pkg:generic/bar?file%3Abar"
-      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "pkg:generic/foo?file%3Afoo"
-      - "pkg:generic/not-baz?file%3Abaz"
-      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file=bar"
+      - "pkg:generic/eggs?file=eggs-packages%2Feggs"
+      - "pkg:generic/foo?file=foo"
+      - "pkg:generic/not-baz?file=baz"
+      - "pkg:generic/spam?file=spam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
@@ -807,23 +807,23 @@ workspaces:
   - name: bar
     type: library
     version: file:bar
-    purl: pkg:generic/bar?file%3Abar
+    purl: pkg:generic/bar?file=bar
   - name: eggs
     type: library
     version: file:eggs-packages/eggs
-    purl: pkg:generic/eggs?file%3Aeggs-packages%2Feggs
+    purl: pkg:generic/eggs?file=eggs-packages%2Feggs
   - name: foo
     type: library
     version: file:foo
-    purl: pkg:generic/foo?file%3Afoo
+    purl: pkg:generic/foo?file=foo
   - name: not-baz
     type: library
     version: file:baz
-    purl: pkg:generic/not-baz?file%3Abaz
+    purl: pkg:generic/not-baz?file=baz
   - name: spam
     type: library
     version: file:spam-packages/spam
-    purl: pkg:generic/spam?file%3Aspam-packages%2Fspam
+    purl: pkg:generic/spam?file=spam-packages%2Fspam
   - name: npm_test
     type: library
     version: 1.1.0
@@ -914,12 +914,12 @@ multiple-dep-versions:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-with-multiple-dep-versions@97070a9eb06bad62eb581890731221660ade9ea3"
     dep_purls:
-      - "pkg:generic/foo?file%3Afoo"
+      - "pkg:generic/foo?file=foo"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%231187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%2375dd3a181375162eda014984f2decc663199b09e"
     source_purls:
       - "pkg:generic/cachito-npm-without-deps?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fcachito-testing%2Fcachito-npm-without-deps.git%232f0ce1d7b1f8b35572d919428b965285a69583f6"
-      - "pkg:generic/foo?file%3Afoo"
+      - "pkg:generic/foo?file=foo"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%231187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%2375dd3a181375162eda014984f2decc663199b09e"
   sbom:
@@ -930,7 +930,7 @@ multiple-dep-versions:
   - name: foo
     type: library
     version: file:foo
-    purl: pkg:generic/foo?file%3Afoo
+    purl: pkg:generic/foo?file=foo
   - name: is-positive
     type: library
     version: git+ssh://git@github.com/kevva/is-positive.git#1187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf

--- a/tests/integration/test_data/npm_packages.yaml
+++ b/tests/integration/test_data/npm_packages.yaml
@@ -782,22 +782,22 @@ workspaces:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-workspaces@b4ec59868cb5667deb62930859762b107f23598c"
     dep_purls:
-      - "generic/bar?file%3Abar"
-      - "generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "generic/foo?file%3Afoo"
-      - "generic/not-baz?file%3Abaz"
-      - "generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file%3Abar"
+      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "pkg:generic/foo?file%3Afoo"
+      - "pkg:generic/not-baz?file%3Abaz"
+      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
       - "pkg:npm/dateformat@5.0.3"
       - "pkg:npm/uuid@9.0.0"
     source_purls:
-      - "generic/bar?file%3Abar"
-      - "generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "generic/foo?file%3Afoo"
-      - "generic/not-baz?file%3Abaz"
-      - "generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file%3Abar"
+      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "pkg:generic/foo?file%3Afoo"
+      - "pkg:generic/not-baz?file%3Abaz"
+      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
@@ -807,23 +807,23 @@ workspaces:
   - name: bar
     type: library
     version: file:bar
-    purl: generic/bar?file%3Abar
+    purl: pkg:generic/bar?file%3Abar
   - name: eggs
     type: library
     version: file:eggs-packages/eggs
-    purl: generic/eggs?file%3Aeggs-packages%2Feggs
+    purl: pkg:generic/eggs?file%3Aeggs-packages%2Feggs
   - name: foo
     type: library
     version: file:foo
-    purl: generic/foo?file%3Afoo
+    purl: pkg:generic/foo?file%3Afoo
   - name: not-baz
     type: library
     version: file:baz
-    purl: generic/not-baz?file%3Abaz
+    purl: pkg:generic/not-baz?file%3Abaz
   - name: spam
     type: library
     version: file:spam-packages/spam
-    purl: generic/spam?file%3Aspam-packages%2Fspam
+    purl: pkg:generic/spam?file%3Aspam-packages%2Fspam
   - name: npm_test
     type: library
     version: 1.1.0
@@ -914,23 +914,23 @@ multiple-dep-versions:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-npm-with-multiple-dep-versions@97070a9eb06bad62eb581890731221660ade9ea3"
     dep_purls:
-      - "generic/foo?file%3Afoo"
+      - "pkg:generic/foo?file%3Afoo"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%231187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%2375dd3a181375162eda014984f2decc663199b09e"
     source_purls:
-      - "generic/foo?file%3Afoo"
       - "pkg:generic/cachito-npm-without-deps?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fcachito-testing%2Fcachito-npm-without-deps.git%232f0ce1d7b1f8b35572d919428b965285a69583f6"
+      - "pkg:generic/foo?file%3Afoo"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%231187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf"
       - "pkg:generic/is-positive?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fkevva%2Fis-positive.git%2375dd3a181375162eda014984f2decc663199b09e"
   sbom:
-  - name: foo
-    type: library
-    version: file:foo
-    purl: generic/foo?file%3Afoo
   - name: cachito-npm-without-deps
     type: library
     version: git+ssh://git@github.com/cachito-testing/cachito-npm-without-deps.git#2f0ce1d7b1f8b35572d919428b965285a69583f6
     purl: pkg:generic/cachito-npm-without-deps?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2Fcachito-testing%2Fcachito-npm-without-deps.git%232f0ce1d7b1f8b35572d919428b965285a69583f6
+  - name: foo
+    type: library
+    version: file:foo
+    purl: pkg:generic/foo?file%3Afoo
   - name: is-positive
     type: library
     version: git+ssh://git@github.com/kevva/is-positive.git#1187a61f2e18cf7c11c23d61a1bd52b9fa6a5fdf

--- a/tests/integration/test_data/yarn_packages.yaml
+++ b/tests/integration/test_data/yarn_packages.yaml
@@ -573,22 +573,22 @@ workspaces:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-yarn-workspaces@85e43d6b682d0e6420a6e4bcaf3072798d5254de"
     dep_purls:
-      - "generic/bar?file%3Abar"
-      - "generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "generic/foo?file%3Afoo"
-      - "generic/not-baz?file%3Abaz"
-      - "generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file%3Abar"
+      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "pkg:generic/foo?file%3Afoo"
+      - "pkg:generic/not-baz?file%3Abaz"
+      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
       - "pkg:npm/dateformat@5.0.3"
       - "pkg:npm/uuid@9.0.0"
     source_purls:
-      - "generic/bar?file%3Abar"
-      - "generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "generic/foo?file%3Afoo"
-      - "generic/not-baz?file%3Abaz"
-      - "generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file%3Abar"
+      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
+      - "pkg:generic/foo?file%3Afoo"
+      - "pkg:generic/not-baz?file%3Abaz"
+      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
@@ -598,23 +598,23 @@ workspaces:
   - name: bar
     type: library
     version: file:bar
-    purl: generic/bar?file%3Abar
+    purl: pkg:generic/bar?file%3Abar
   - name: eggs
     type: library
     version: file:eggs-packages/eggs
-    purl: generic/eggs?file%3Aeggs-packages%2Feggs
+    purl: pkg:generic/eggs?file%3Aeggs-packages%2Feggs
   - name: foo
     type: library
     version: file:foo
-    purl: generic/foo?file%3Afoo
+    purl: pkg:generic/foo?file%3Afoo
   - name: not-baz
     type: library
     version: file:baz
-    purl: generic/not-baz?file%3Abaz
+    purl: pkg:generic/not-baz?file%3Abaz
   - name: spam
     type: library
     version: file:spam-packages/spam
-    purl: generic/spam?file%3Aspam-packages%2Fspam
+    purl: pkg:generic/spam?file%3Aspam-packages%2Fspam
   - name: npm_test
     type: library
     version: 1.1.0

--- a/tests/integration/test_data/yarn_packages.yaml
+++ b/tests/integration/test_data/yarn_packages.yaml
@@ -573,22 +573,22 @@ workspaces:
   content_manifest:
   - purl: "pkg:github/cachito-testing/cachito-yarn-workspaces@85e43d6b682d0e6420a6e4bcaf3072798d5254de"
     dep_purls:
-      - "pkg:generic/bar?file%3Abar"
-      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "pkg:generic/foo?file%3Afoo"
-      - "pkg:generic/not-baz?file%3Abaz"
-      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file=bar"
+      - "pkg:generic/eggs?file=eggs-packages%2Feggs"
+      - "pkg:generic/foo?file=foo"
+      - "pkg:generic/not-baz?file=baz"
+      - "pkg:generic/spam?file=spam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
       - "pkg:npm/dateformat@5.0.3"
       - "pkg:npm/uuid@9.0.0"
     source_purls:
-      - "pkg:generic/bar?file%3Abar"
-      - "pkg:generic/eggs?file%3Aeggs-packages%2Feggs"
-      - "pkg:generic/foo?file%3Afoo"
-      - "pkg:generic/not-baz?file%3Abaz"
-      - "pkg:generic/spam?file%3Aspam-packages%2Fspam"
+      - "pkg:generic/bar?file=bar"
+      - "pkg:generic/eggs?file=eggs-packages%2Feggs"
+      - "pkg:generic/foo?file=foo"
+      - "pkg:generic/not-baz?file=baz"
+      - "pkg:generic/spam?file=spam-packages%2Fspam"
       - "pkg:npm/abbrev@2.0.0"
       - "pkg:npm/classnames@2.3.2"
       - "pkg:npm/colors@1.4.0"
@@ -598,23 +598,23 @@ workspaces:
   - name: bar
     type: library
     version: file:bar
-    purl: pkg:generic/bar?file%3Abar
+    purl: pkg:generic/bar?file=bar
   - name: eggs
     type: library
     version: file:eggs-packages/eggs
-    purl: pkg:generic/eggs?file%3Aeggs-packages%2Feggs
+    purl: pkg:generic/eggs?file=eggs-packages%2Feggs
   - name: foo
     type: library
     version: file:foo
-    purl: pkg:generic/foo?file%3Afoo
+    purl: pkg:generic/foo?file=foo
   - name: not-baz
     type: library
     version: file:baz
-    purl: pkg:generic/not-baz?file%3Abaz
+    purl: pkg:generic/not-baz?file=baz
   - name: spam
     type: library
     version: file:spam-packages/spam
-    purl: pkg:generic/spam?file%3Aspam-packages%2Fspam
+    purl: pkg:generic/spam?file=spam-packages%2Fspam
   - name: npm_test
     type: library
     version: 1.1.0

--- a/tests/test_content_manifest.py
+++ b/tests/test_content_manifest.py
@@ -1566,7 +1566,7 @@ def test_set_go_package_sources(mock_warning, app, pkg_name, gomod_data, warn, d
         ],
         [
             {"name": "fromfile", "type": "npm", "version": "file:client-default"},
-            "pkg:generic/fromfile?file%3Aclient-default",
+            "pkg:generic/fromfile?file=client-default",
             None,
             True,
             True,
@@ -1698,7 +1698,7 @@ def test_set_go_package_sources(mock_warning, app, pkg_name, gomod_data, warn, d
         ],
         [
             {"name": "fromfile", "type": "yarn", "version": "file:client-default"},
-            "pkg:generic/fromfile?file%3Aclient-default",
+            "pkg:generic/fromfile?file=client-default",
             None,
             True,
             True,

--- a/tests/test_content_manifest.py
+++ b/tests/test_content_manifest.py
@@ -1566,7 +1566,7 @@ def test_set_go_package_sources(mock_warning, app, pkg_name, gomod_data, warn, d
         ],
         [
             {"name": "fromfile", "type": "npm", "version": "file:client-default"},
-            "generic/fromfile?file%3Aclient-default",
+            "pkg:generic/fromfile?file%3Aclient-default",
             None,
             True,
             True,
@@ -1698,7 +1698,7 @@ def test_set_go_package_sources(mock_warning, app, pkg_name, gomod_data, warn, d
         ],
         [
             {"name": "fromfile", "type": "yarn", "version": "file:client-default"},
-            "generic/fromfile?file%3Aclient-default",
+            "pkg:generic/fromfile?file%3Aclient-default",
             None,
             True,
             True,


### PR DESCRIPTION
The pkg scheme is required for each component according to the PURL specification.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n\a] New code has type annotations
- [n\a] OpenAPI schema is updated (if applicable)
- [n\a] DB schema change has corresponding DB migration (if applicable)
- [n\a] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
