### PR TITLE
Skip checking int test request metrics in prod

### DIFF
--- a/tests/integration/test_request_metrics.py
+++ b/tests/integration/test_request_metrics.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import os
 from datetime import datetime
+
+import pytest
 
 from . import utils
 
@@ -24,6 +27,10 @@ def test_get_request_metrics(api_client):
     assert request_metrics["time_in_queue"] > 0
 
 
+@pytest.mark.skipif(
+    "cachito-prod" in str(os.environ.get("JOB_NAME")),
+    reason="Test is skipped in production environment",
+)
 def test_get_request_metrics_summary(api_client):
     finished_from = datetime.utcnow().isoformat()
     env_data = utils.load_test_data("pip_packages.yaml")["without_deps"]


### PR DESCRIPTION
Integration test test_get_request_metrics is constantly failing with following error: urllib3.exceptions.ResponseError: too many 504 error responses

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] OpenAPI schema is updated (if applicable)
- [n/a] DB schema change has corresponding DB migration (if applicable)
- [n/a] README updated (if worker configuration changed, or if applicable)
- [n/a] Draft release notes are updated before merging
