### PR TITLE
Full Go 1.21 support

### DIFF
--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -541,9 +541,6 @@ paths:
                 GOSUMDB:
                   value: off
                   kind: literal
-                GOTOOLCHAIN:
-                  value: local
-                  kind: literal
         "404":
           description: The request wasn't found
           content:

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -31,7 +31,6 @@ class Config(object):
     cachito_default_environment_variables = {
         "gomod": {
             "GOSUMDB": {"value": "off", "kind": "literal"},
-            "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
         },
         "npm": {
             "CHROMEDRIVER_SKIP_DOWNLOAD": {"value": "true", "kind": "literal"},
@@ -164,7 +163,6 @@ class TestingConfig(DevelopmentConfig):
         "gomod": {
             "GO111MODULE": {"value": "on", "kind": "literal"},
             "GOSUMDB": {"value": "off", "kind": "literal"},
-            "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
         },
         "npm": {
             "CHROMEDRIVER_SKIP_DOWNLOAD": {"value": "true", "kind": "literal"},

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -320,6 +320,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
         run_params = {"env": env, "cwd": app_source_path}
 
         go = _select_go_toolchain(app_source_path)
+        log.info(f"Using Go release: {go.release}")
 
         # Collect all the dependency names that are being replaced to later report which
         # dependencies were replaced

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -166,7 +166,6 @@ def fetch_gomod_source(request_id, dep_replacements=None, package_configs=None):
         "GOCACHE": {"value": "deps/gomod", "kind": "path"},
         "GOPATH": {"value": "deps/gomod", "kind": "path"},
         "GOMODCACHE": {"value": "deps/gomod/pkg/mod", "kind": "path"},
-        "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
     }
     env_vars.update(config.cachito_default_environment_variables.get("gomod", {}))
     update_request_env_vars(request_id, env_vars)

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -35,7 +35,7 @@ RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
 #   - clean any build artifacts Go creates as part of the process.
 RUN go install 'golang.org/dl/go1.20@latest' && \
     "$HOME/go/bin/go1.20" download && \
-    mkdir /usr/local/go && \
+    mkdir -p /usr/local/go && \
     mv "$HOME/sdk/go1.20" /usr/local/go && \
     rm -rf "$HOME/go" "$HOME/.cache/go-build/"
 

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -33,11 +33,13 @@ RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes \
 #   - move the SDK to a host local install system-wide location
 #   - remove the shim as it forces and expects the SDK to be used from $HOME
 #   - clean any build artifacts Go creates as part of the process.
-RUN go install 'golang.org/dl/go1.20@latest' && \
-    "$HOME/go/bin/go1.20" download && \
-    mkdir -p /usr/local/go && \
-    mv "$HOME/sdk/go1.20" /usr/local/go && \
-    rm -rf "$HOME/go" "$HOME/.cache/go-build/"
+RUN for go_ver in "go1.20" "go1.21.0"; do \
+        go install "golang.org/dl/${go_ver}@latest" && \
+        "$HOME/go/bin/$go_ver" download && \
+        mkdir -p /usr/local/go && \
+        mv "$HOME/sdk/$go_ver" /usr/local/go && \
+        rm -rf "$HOME/go" "$HOME/.cache/go-build/"; \
+    done
 
 # Use the system CA bundle for the requests library
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/directory-hash/ca-bundle.crt

--- a/tests/helper_utils/__init__.py
+++ b/tests/helper_utils/__init__.py
@@ -4,14 +4,16 @@ from pathlib import Path
 from typing import Union
 
 
-def assert_directories_equal(dir_a, dir_b):
+def assert_directories_equal(dir_a, dir_b, ignore_files=[]):
     """
     Check recursively directories have equal content.
 
     :param dir_a: first directory to check
     :param dir_b: second directory to check
     """
-    dirs_cmp = filecmp.dircmp(dir_a, dir_b)
+    ignore_files = list(set(filecmp.DEFAULT_IGNORES).union(ignore_files))
+    dirs_cmp = filecmp.dircmp(dir_a, dir_b, ignore=ignore_files)
+
     assert (
         len(dirs_cmp.left_only) == 0
     ), f"Found files: {dirs_cmp.left_only} in {dir_a}, but not {dir_b}."
@@ -28,7 +30,7 @@ def assert_directories_equal(dir_a, dir_b):
     for common_dir in dirs_cmp.common_dirs:
         inner_a = os.path.join(dir_a, common_dir)
         inner_b = os.path.join(dir_b, common_dir)
-        assert_directories_equal(inner_a, inner_b)
+        assert_directories_equal(inner_a, inner_b, ignore_files)
 
 
 class Symlink(str):

--- a/tests/integration/test_data/gomod_packages.yaml
+++ b/tests/integration/test_data/gomod_packages.yaml
@@ -5825,6 +5825,9 @@ go_1.21:
   expected_files:
     app: https://github.com/cachito-testing/retrodep/tarball/d0c316edef82e527fed5713f9960cfe7f7c29945
     deps/gomod/pkg/mod/cache/download/: https://github.com/cachito-testing/test_files/raw/master/retrodep-deps-go-1_21.tar.gz
+  ignore_files:
+    deps/gomod/pkg/mod/cache/download/:
+      - sumdb
   content_manifest:
   - purl: "pkg:golang/github.com%2Frelease-engineering%2Fretrodep%2Fv2@v2.1.2-0.20240308152237-d0c316edef82"
     dep_purls:

--- a/tests/integration/test_packages.py
+++ b/tests/integration/test_packages.py
@@ -94,7 +94,13 @@ def test_packages(env_package, env_name, test_env, tmpdir):
     client.download_and_extract_archive(completed_response.id, tmpdir)
     source_path = tmpdir.join(f"download_{str(completed_response.id)}")
     expected_files = env_data["expected_files"]
-    utils.assert_expected_files(source_path, expected_files, tmpdir)
+
+    # File or directory names that will be ignored when checking the request output contents.
+    # Note that these do not represent absolute paths, so any file or directory that matches
+    # a name will be ignored.
+    ignore_files = env_data.get("ignore_files", {})
+
+    utils.assert_expected_files(source_path, expected_files, tmpdir, ignore_files)
 
     image_contents = utils.parse_image_contents(env_data.get("content_manifest"))
     utils.assert_content_manifest(client, completed_response.id, image_contents)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -350,7 +350,7 @@ def assert_elements_from_response(response_data, expected_response_data):
         )
 
 
-def assert_expected_files(source_path, expected_files, tmpdir):
+def assert_expected_files(source_path, expected_files, tmpdir, ignore_files={}):
     """
     Check that the source path includes expected files in directories.
 
@@ -397,8 +397,13 @@ def assert_expected_files(source_path, expected_files, tmpdir):
             assert os.path.isdir(
                 expected_package_root_dir
             ), f"Wrong directory path {expected_package_root_dir}."
+
+            ignore_files_for_dir = ignore_files.get(dir_to_check, [])
+
             # Compare and assert files in directory with expected data
-            assert_directories_equal(package_root_dir, expected_package_root_dir)
+            assert_directories_equal(
+                package_root_dir, expected_package_root_dir, ignore_files_for_dir
+            )
             # Delete temporary data
             for temp_data in [deps_data_path, expected_data_path, expected_archive]:
                 if os.path.isdir(temp_data):

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -1288,13 +1288,13 @@ def test_get_gomod_version_fail(go_mod_file: Path) -> None:
     "base_release, go_mod_file, expected_toolchain",
     [
         pytest.param("go1.20.7", "go 1.20", "1.20.7", id="old_base_version_equals_modfile"),
-        pytest.param("go1.21.4", "go 1.21.0", "1.21.4", id="new_base_version_equals_modfile"),
+        pytest.param("go1.21.4", "go 1.21.0", "1.21.0", id="new_base_version_equals_modfile"),
         pytest.param("go1.20.7", "go 1.21.0", "1.21.0", id="modfile_requires_newer_toolchain"),
-        pytest.param("go1.21.4", "go 1.21.9", "1.21.4", id="modfile_requires_newer_121_toolchain"),
+        pytest.param("go1.21.4", "go 1.21.9", "1.21.0", id="modfile_requires_newer_121_toolchain"),
         pytest.param("go1.21.4", "go 1.20", "1.20", id="modfile_requires_older_toolchain"),
         pytest.param("go1.20", "", "1.20", id="no_modfile_version_use_base_toolchain"),
         pytest.param("go1.21.4", "", "1.20", id="no_modfile_version_use_older_toolchain"),
-        pytest.param("go1.21.6", "toolchain go1.21.4", "1.21.6", id="decide_based_on_toolchain"),
+        pytest.param("go1.21.6", "toolchain go1.21.4", "1.21.0", id="decide_based_on_toolchain"),
     ],
     indirect=["go_mod_file"],
 )
@@ -1345,7 +1345,7 @@ class TestGo:
             pytest.param(
                 "/usr/bin/go1.21",
                 {
-                    "env": {"GOCACHE": "/foo", "GOTOOLCHAIN": "local"},
+                    "env": {"GOCACHE": "/foo", "GOTOOLCHAIN": "auto"},
                     "cwd": "/foo/bar",
                     "text": True,
                 },
@@ -1377,7 +1377,7 @@ class TestGo:
             pytest.param(
                 None,
                 {
-                    "env": {"GOCACHE": "/foo", "GOTOOLCHAIN": "local"},
+                    "env": {"GOCACHE": "/foo", "GOTOOLCHAIN": "auto"},
                     "cwd": "/foo/bar",
                     "text": True,
                 },
@@ -1473,7 +1473,7 @@ class TestGo:
         retry: bool,
     ) -> None:
 
-        env = {"env": {"GOTOOLCHAIN": "local", "GOCACHE": "foo", "GOPATH": "bar"}}
+        env = {"env": {"GOTOOLCHAIN": "auto", "GOCACHE": "foo", "GOPATH": "bar"}}
         opts = ["mod", "download"]
         go = gomod.Go(release=release)
         go(opts, retry=retry, params=env)

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -1266,32 +1266,30 @@ def test_get_gomod_version_fail(tmp_path: Path, go_mod_file: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "base_release,modfile_version,used_version",
+    "base_release, go_mod_file, expected_toolchain",
     [
-        pytest.param("go1.20.7", "1.20", "1.20.7", id="old_base_version_equals_modfile"),
-        pytest.param("go1.21.4", "1.21.0", "1.21.4", id="new_base_version_equals_modfile"),
-        pytest.param("go1.20.7", "1.21.0", "1.21.0", id="modfile_requires_newer_toolchain"),
-        pytest.param("go1.21.4", "1.21.9", "1.21.4", id="modfile_requires_newer_121_toolchain"),
-        pytest.param("go1.21.4", "1.20", "1.20", id="modfile_requires_older_toolchain"),
-        pytest.param("go1.20", None, "1.20", id="no_modfile_version_use_base_toolchain"),
-        pytest.param("go1.21.4", None, "1.20", id="no_modfile_version_use_older_toolchain"),
+        pytest.param("go1.20.7", "go 1.20", "1.20.7", id="old_base_version_equals_modfile"),
+        pytest.param("go1.21.4", "go 1.21.0", "1.21.4", id="new_base_version_equals_modfile"),
+        pytest.param("go1.20.7", "go 1.21.0", "1.21.0", id="modfile_requires_newer_toolchain"),
+        pytest.param("go1.21.4", "go 1.21.9", "1.21.4", id="modfile_requires_newer_121_toolchain"),
+        pytest.param("go1.21.4", "go 1.20", "1.20", id="modfile_requires_older_toolchain"),
+        pytest.param("go1.20", "", "1.20", id="no_modfile_version_use_base_toolchain"),
+        pytest.param("go1.21.4", "", "1.20", id="no_modfile_version_use_older_toolchain"),
     ],
+    indirect=["go_mod_file"],
 )
-@mock.patch("cachito.workers.pkg_managers.gomod._get_gomod_version")
-@mock.patch("cachito.workers.pkg_managers.gomod.Go._run")
+@mock.patch("cachito.workers.pkg_managers.gomod.Go.__call__")
 def test_select_go_toolchain(
-    mock_go_run: mock.Mock,
-    mock_get_gomod_version: mock.Mock,
+    mock_go_call: mock.Mock,
     tmp_path: Path,
     base_release: str,
-    modfile_version: str,
-    used_version: str,
+    go_mod_file: Path,
+    expected_toolchain: str,
 ) -> None:
-    mock_go_run.return_value = base_release
-    mock_get_gomod_version.return_value = modfile_version
+    mock_go_call.return_value = f"Go release: {base_release}"
 
     go = gomod._select_go_toolchain(tmp_path)
-    assert go.version == Version(used_version)
+    assert go.version == Version(expected_toolchain)
 
 
 class TestGo:

--- a/tests/test_workers/test_pkg_managers/test_gomod.py
+++ b/tests/test_workers/test_pkg_managers/test_gomod.py
@@ -1253,7 +1253,7 @@ def test_vendor_changed(subpath, vendor_before, vendor_changes, expected_change,
     indirect=["go_mod_file"],
 )
 def test_get_gomod_version(tmp_path: Path, go_mod_file: Path, go_mod_version: str) -> None:
-    assert gomod._get_gomod_version(tmp_path) == go_mod_version
+    assert gomod._get_gomod_version(tmp_path / "go.mod") == go_mod_version
 
 
 @pytest.mark.parametrize(
@@ -1262,7 +1262,7 @@ def test_get_gomod_version(tmp_path: Path, go_mod_file: Path, go_mod_version: st
     indirect=True,
 )
 def test_get_gomod_version_fail(tmp_path: Path, go_mod_file: Path) -> None:
-    assert gomod._get_gomod_version(tmp_path) is None
+    assert gomod._get_gomod_version(tmp_path / "go.mod") is None
 
 
 @pytest.mark.parametrize(
@@ -1288,7 +1288,7 @@ def test_select_go_toolchain(
 ) -> None:
     mock_go_call.return_value = f"Go release: {base_release}"
 
-    go = gomod._select_go_toolchain(tmp_path)
+    go = gomod._select_go_toolchain(tmp_path / "go.mod")
     assert go.version == Version(expected_toolchain)
 
 

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -114,7 +114,6 @@ def test_fetch_gomod_source(
     env_vars = {
         "GO111MODULE": {"value": "on", "kind": "literal"},
         "GOSUMDB": {"value": "off", "kind": "literal"},
-        "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
     }
     sample_env_vars.update(env_vars)
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] ~OpenAPI schema is updated (if applicable)~
- [ ] ~DB schema change has corresponding DB migration (if applicable)~
- [ ] ~README updated (if worker configuration changed, or if applicable)~
- [ ] Draft release notes are updated before merging
