### PR TITLE
Follow-up fixes for !996 

### DIFF
--- a/cachito/web/static/api_v1.yaml
+++ b/cachito/web/static/api_v1.yaml
@@ -1219,9 +1219,6 @@ components:
             GOPATH:
               value: deps/gomod
               kind: path
-            GOSUMDB:
-              value: off
-              kind: literal
             GOTOOLCHAIN:
               value: local
               kind: literal

--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -29,9 +29,6 @@ class Config(object):
     cachito_archives_minimum_age_days = 365
     cachito_auth_type: Optional[str] = None
     cachito_default_environment_variables = {
-        "gomod": {
-            "GOSUMDB": {"value": "off", "kind": "literal"},
-        },
         "npm": {
             "CHROMEDRIVER_SKIP_DOWNLOAD": {"value": "true", "kind": "literal"},
             "CYPRESS_INSTALL_BINARY": {"value": "0", "kind": "literal"},
@@ -162,7 +159,6 @@ class TestingConfig(DevelopmentConfig):
     cachito_default_environment_variables = {
         "gomod": {
             "GO111MODULE": {"value": "on", "kind": "literal"},
-            "GOSUMDB": {"value": "off", "kind": "literal"},
         },
         "npm": {
             "CHROMEDRIVER_SKIP_DOWNLOAD": {"value": "true", "kind": "literal"},

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -313,6 +313,7 @@ def resolve_gomod(app_source_path, request, dep_replacements=None, git_dir_path=
             "PATH": os.environ.get("PATH", ""),
             "GOMODCACHE": "{}/pkg/mod".format(temp_dir),
             "GOTOOLCHAIN": "auto",
+            "GOSUMDB": "sum.golang.org",
         }
         if "cgo-disable" in request.get("flags", []):
             env["CGO_ENABLED"] = "0"

--- a/tests/helper_utils/__init__.py
+++ b/tests/helper_utils/__init__.py
@@ -4,12 +4,13 @@ from pathlib import Path
 from typing import Union
 
 
-def assert_directories_equal(dir_a, dir_b, ignore_files=[]):
+def assert_directories_equal(dir_a, dir_b, ignore_files=()):
     """
     Check recursively directories have equal content.
 
     :param dir_a: first directory to check
     :param dir_b: second directory to check
+    :param ignore_files: a sequence of file names to be ignored in the comparisons
     """
     ignore_files = list(set(filecmp.DEFAULT_IGNORES).union(ignore_files))
     dirs_cmp = filecmp.dircmp(dir_a, dir_b, ignore=ignore_files)

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -113,7 +113,6 @@ def test_fetch_gomod_source(
     # Add the default environment variables from the configuration
     env_vars = {
         "GO111MODULE": {"value": "on", "kind": "literal"},
-        "GOSUMDB": {"value": "off", "kind": "literal"},
     }
     sample_env_vars.update(env_vars)
 


### PR DESCRIPTION
- follow good practice of not using a list as a default argument due to immutability in integration tests
- drop most explicit `GOSUMDB=off` assignments and only set it to its default value for `resolve_gomod`

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
