### PR TITLE
Preliminary support for Go 1.22

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -1077,7 +1077,7 @@ def _get_gomod_version(go_mod_file: Path) -> Tuple[Optional[str], Optional[str]]
 def _select_go_toolchain(go_mod_file: Path) -> Go:
     go = Go()
     target_version = None
-    go_max_version = pkgver.Version("1.21")
+    go_max_version = pkgver.Version("1.22")
     go_121_version = pkgver.Version("1.21")
     go_base_version = go.version
     go_mod_version_msg = "go.mod reported versions: '{}'[go], '{}'[toolchain]"

--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -1078,6 +1078,7 @@ def _select_go_toolchain(go_mod_file: Path) -> Go:
     go = Go()
     target_version = None
     go_max_version = pkgver.Version("1.21")
+    go_121_version = pkgver.Version("1.21")
     go_base_version = go.version
     go_mod_version_msg = "go.mod reported versions: '{}'[go], '{}'[toolchain]"
 
@@ -1111,13 +1112,13 @@ def _select_go_toolchain(go_mod_file: Path) -> Go:
             f"Required/recommended Go toolchain version '{target_version}' is not supported yet.",
         )
 
-    if target_version >= go_max_version:
+    if target_version >= go_121_version:
         # Project makes use of Go >=1.21:
         # - always use the 'X.Y.0' toolchain to make sure GOTOOLCHAIN=auto fetches anything newer
         # - container environments need to have it pre-installed
         # - local environments will always install 1.21.0 SDK and then pull any newer toolchain
         go = Go(release="go1.21.0")
-    elif go_base_version >= go_max_version:
+    elif go_base_version >= go_121_version:
         # Starting with Go 1.21, Go doesn't try to be semantically backwards compatible in that
         # the 'go X.Y' line now denotes the minimum required version of Go, not a "suggested"
         # version. What it means in practice is that a Go toolchain >= 1.21 enforces the biggest

--- a/cachito/workers/tasks/gomod.py
+++ b/cachito/workers/tasks/gomod.py
@@ -4,13 +4,7 @@ import os
 from pathlib import Path
 
 from cachito.common.packages_data import PackagesData
-from cachito.errors import (
-    FileAccessError,
-    GoModError,
-    InvalidRepoStructure,
-    InvalidRequestData,
-    UnsupportedFeature,
-)
+from cachito.errors import FileAccessError, GoModError, InvalidRequestData, UnsupportedFeature
 from cachito.workers.config import get_worker_config
 from cachito.workers.paths import RequestBundleDir
 from cachito.workers.pkg_managers.general import update_request_env_vars
@@ -68,7 +62,7 @@ def _is_workspace(repo_root: Path, subpath: str):
 def _fail_if_bundle_dir_has_workspaces(bundle_dir: RequestBundleDir, subpaths: list[str]):
     for subpath in subpaths:
         if _is_workspace(bundle_dir.source_root_dir, subpath):
-            raise InvalidRepoStructure("Go workspaces are not supported by Cachito.")
+            raise UnsupportedFeature("Go workspaces are not supported by Cachito.")
 
 
 def _fail_if_parent_replacement_not_included(packages_json_data: PackagesData) -> None:

--- a/tests/test_workers/test_tasks/test_gomod.py
+++ b/tests/test_workers/test_tasks/test_gomod.py
@@ -9,12 +9,7 @@ import pytest
 
 from cachito.common.packages_data import PackagesData
 from cachito.common.paths import RequestBundleDir
-from cachito.errors import (
-    FileAccessError,
-    InvalidRepoStructure,
-    InvalidRequestData,
-    UnsupportedFeature,
-)
+from cachito.errors import FileAccessError, InvalidRequestData, UnsupportedFeature
 from cachito.workers import tasks
 from cachito.workers.tasks import gomod
 
@@ -366,7 +361,7 @@ def test_fail_if_bundle_dir_has_workspaces(add_go_work_file, tmpdir):
 
     if add_go_work_file:
         Path(bundle_dir.source_root_dir / "go.work").touch()
-        with pytest.raises(InvalidRepoStructure):
+        with pytest.raises(UnsupportedFeature):
             gomod._fail_if_bundle_dir_has_workspaces(bundle_dir, ["."])
     else:
         gomod._fail_if_bundle_dir_has_workspaces(bundle_dir, ["."])


### PR DESCRIPTION
This PR basically just bumps the maximum supported version to 1.22 from 1.21. The changes don't include everything that 1.22 brings, most notably vendored workspaces (we don't even support base workspaces).

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
