### PR TITLE
Remove PATH deps allowlist for rubygems

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -62,7 +62,6 @@ class Config(object):
     cachito_nexus_username = "cachito"
     cachito_npm_file_deps_allowlist: Dict[str, List[str]] = {}
     cachito_yarn_file_deps_allowlist: Dict[str, List[str]] = {}
-    cachito_rubygems_file_deps_allowlist: Dict[str, List[str]] = {}
     cachito_request_file_logs_dir: Optional[str] = None
     cachito_request_file_logs_format = (
         "[%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s] %(message)s"
@@ -135,10 +134,6 @@ class DevelopmentConfig(Config):
     cachito_nexus_url = "http://nexus:8081"
     cachito_npm_file_deps_allowlist = {"cachito-npm-test": ["subpackage"]}
     cachito_yarn_file_deps_allowlist = {"cachito-yarn-test": ["subpackage"]}
-    cachito_rubygems_file_deps_allowlist = {
-        "cachito-rubygems-with-dependencies": ["pathgem"],
-        "cachito-rubygems-multiple/first_pkg": ["pathgem"],
-    }
     cachito_request_file_logs_dir: Optional[str] = "/var/log/cachito/requests"
     cachito_sources_dir = os.path.join(ARCHIVES_VOLUME, "sources")
     cachito_jaeger_exporter_endpoint = "jaeger"

--- a/tests/test_workers/test_pkg_managers/test_rubygems.py
+++ b/tests/test_workers/test_pkg_managers/test_rubygems.py
@@ -8,7 +8,7 @@ import git
 import pytest
 import requests
 
-from cachito.errors import GitError, NexusError, UnsupportedFeature, ValidationError
+from cachito.errors import GitError, NexusError, ValidationError
 from cachito.workers.errors import NexusScriptError, UploadError
 from cachito.workers.pkg_managers import general, rubygems
 from cachito.workers.pkg_managers.rubygems import GemMetadata, parse_gemlock
@@ -535,7 +535,6 @@ class TestDownload:
             mock_shutil_copy.assert_called_once_with(git_archive_path, download_info["path"])
 
     @pytest.mark.parametrize("have_raw_component", [True, False])
-    @pytest.mark.parametrize("path_dep_is_allowed", [True, False])
     @mock.patch("cachito.workers.pkg_managers.rubygems.RequestBundleDir")
     @mock.patch("cachito.workers.pkg_managers.rubygems.get_worker_config")
     @mock.patch("cachito.workers.pkg_managers.rubygems.nexus.get_nexus_hoster_credentials")
@@ -552,7 +551,6 @@ class TestDownload:
         mock_get_nexus_creds,
         mock_get_config,
         mock_request_bundle_dir,
-        path_dep_is_allowed,
         have_raw_component,
         tmp_path,
         caplog,
@@ -605,26 +603,13 @@ class TestDownload:
         mock_rubygems_download.return_value = rubygems_info
         mock_git_download.return_value = git_info
         mock_get_path_info.return_value = path_info
-
-        if path_dep_is_allowed:
-            allowed_path_deps = {path_info["name"]}
-        else:
-            allowed_path_deps = {}
-
         request_id = 1
         # </setup>
 
         # <exercise>
-        if path_dep_is_allowed:
-            downloads = rubygems.download_dependencies(
-                request_id, dependencies, mock_bundle_dir.source_root_dir, allowed_path_deps
-            )
-        else:
-            with pytest.raises(UnsupportedFeature):
-                rubygems.download_dependencies(
-                    request_id, dependencies, mock_bundle_dir.source_root_dir, allowed_path_deps
-                )
-            return
+        downloads = rubygems.download_dependencies(
+            request_id, dependencies, mock_bundle_dir.source_root_dir
+        )
         # </exercise>
 
         # <verify>


### PR DESCRIPTION
Remove the PATH deps allowlist for rubygems.

There is also an additional commit that allows PATH dependencies from anywhere in the request repository rather than just from the package directory. I can drop that commit if you disagree.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- N/A OpenAPI schema is updated (if applicable)
- N/A DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
