### PR TITLE
switch to typer-slim and upgrade version to 0.12.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,4 +25,4 @@ opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-sqlalchemy
 opentelemetry-exporter-jaeger
 opentelemetry-exporter-otlp-proto-http
-typer
+typer-slim

--- a/requirements.txt
+++ b/requirements.txt
@@ -286,7 +286,7 @@ click==8.1.7 \
     #   click-plugins
     #   click-repl
     #   commoncode
-    #   typer
+    #   typer-slim
 click-didyoumean==0.3.0 \
     --hash=sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667 \
     --hash=sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035
@@ -883,9 +883,9 @@ text-unidecode==1.3 \
 thrift==0.16.0 \
     --hash=sha256:2b5b6488fcded21f9d312aa23c9ff6a0195d0f6ae26ddbd5ad9e3e25dfc14408
     # via opentelemetry-exporter-jaeger-thrift
-typer==0.9.0 \
-    --hash=sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2 \
-    --hash=sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee
+typer-slim==0.12.3 \
+    --hash=sha256:142c73d91ac1df79a49cec5a1c2210c00b1b4040a91014b539792af5ba81c65c \
+    --hash=sha256:633965eb413074aa6c47549d1820832f229709e9a59857a4f57ee82b655602af
     # via -r requirements.in
 typing-extensions==4.9.0 \
     --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
@@ -893,7 +893,7 @@ typing-extensions==4.9.0 \
     # via
     #   opentelemetry-sdk
     #   pydantic
-    #   typer
+    #   typer-slim
 tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \
     --hash=sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda


### PR DESCRIPTION
Typer 0.12.x started pulling in optional dependencies which aren't necessary for cachito. Switch to typer-slim to avoid those dependencies. The full version is causing a unit test failure that is blocking dependabot PRs.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
