### PR TITLE
Explicitly forbid workspace vendoring

### DIFF
--- a/cachito/workers/pkg_managers/gomod.py
+++ b/cachito/workers/pkg_managers/gomod.py
@@ -382,6 +382,7 @@ def resolve_gomod(
             flags, app_source_path, worker_config.cachito_gomod_strict_vendor
         )
         if should_vendor:
+            _vet_workspace_vendoring(go, run_params)
             downloaded_modules = _vendor_deps(go, run_params, can_make_changes, git_dir_path)
         else:
             log.info("Downloading the gomod dependencies")
@@ -504,6 +505,18 @@ def resolve_gomod(
             "module_deps": main_module_deps,
             "packages": main_packages,
         }
+
+
+def _vet_workspace_vendoring(go: Go, run_params: dict[str, Any]) -> None:
+    go_work_file = go(["env", "GOWORK"], run_params).rstrip()
+
+    if not go_work_file or go_work_file == "off":
+        return
+
+    vendor_dir = Path(go_work_file).parent / "vendor"
+
+    if vendor_dir.is_dir():
+        raise UnsupportedFeature("Workspace vendoring introduced in Go 1.22 is not supported")
 
 
 def _set_local_modules_versions(


### PR DESCRIPTION
The ability to vendor dependencies in projects that make use of workspaces was[ introduced in Go 1.22](https://github.com/golang/go/issues/60056). Cachito currently does not support the use of "go work vendor", so this commit introduces an explicit check for that scenario and a clearer error message.

Note that by design, Go does not allow the use of "go mod vendor" if workspaces are present, so the check assumes that the existence of a vendor folder in a project with workspaces means that workspace vendoring is being used.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
