### PR TITLE
README: Update the Go support version to 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ The table below shows the supported package managers and their support level in 
 
 Tool     | Version |
 ---      |---------|
-Go*      | 1.20.7, 1.21.0  |
+Go*      | 1.20.7, 1.22.0 (no workspace vendoring support)  |
 Npm      | 9.5.0   |
 Node     | 18.16.1 |
 Pip      | 22.3.1  |


### PR DESCRIPTION
When basic support for 1.22, i.e. without workspace vendoring was introduced, the docs wasn't updated accordingly, fix that.

Fixes: fe18efafd943e39065c5e99b7eff9635ebc1e800

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
