### PR TITLE
retry aiohttp requests on ClientConnectionError

### DIFF
--- a/cachito/workers/pkg_managers/general_js.py
+++ b/cachito/workers/pkg_managers/general_js.py
@@ -140,7 +140,9 @@ async def get_dependencies(
 
     trace_config = aiohttp.TraceConfig()
     trace_config.on_request_start.append(on_request_start)
-    retry_options = JitterRetry(attempts=attempts, retry_all_server_errors=True)
+    retry_options = JitterRetry(
+        attempts=attempts, exceptions={aiohttp.ClientConnectionError}, retry_all_server_errors=True
+    )
     retry_client = RetryClient(retry_options=retry_options, trace_configs=[trace_config])
 
     async with retry_client as session:


### PR DESCRIPTION
The aiohttp_retry library appears not to retry any raised Exceptions by default. Retry aiohttp.ClientConnectionError to prevent failed requests on intermittent Nexus connection issues.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] OpenAPI schema is updated (if applicable)
- [ ] DB schema change has corresponding DB migration (if applicable)
- [ ] README updated (if worker configuration changed, or if applicable)
- [ ] Draft release notes are updated before merging
