### PR TITLE
cachito-nexus: Add compatibility toggle for versions that use orientDB

### DIFF
--- a/cachito/workers/config.py
+++ b/cachito/workers/config.py
@@ -50,6 +50,7 @@ class Config(object):
     cachito_nexus_hoster_password: Optional[str] = None
     cachito_nexus_hoster_url: Optional[str] = None
     cachito_nexus_hoster_username: Optional[str] = None
+    cachito_nexus_hoster_is_orient_db = False
     cachito_nexus_js_hosted_repo_name = "cachito-js-hosted"
     cachito_nexus_max_search_attempts = 5
     cachito_nexus_npm_proxy_url = "http://localhost:8081/repository/cachito-js/"
@@ -57,6 +58,7 @@ class Config(object):
     cachito_nexus_rubygems_raw_repo_name = "cachito-rubygems-raw"
     cachito_nexus_proxy_password: Optional[str] = None
     cachito_nexus_proxy_username: Optional[str] = None
+    cachito_nexus_proxy_is_orient_db = False
     cachito_nexus_request_repo_prefix = "cachito-"
     cachito_nexus_timeout = 60
     cachito_nexus_username = "cachito"


### PR DESCRIPTION
Nexus has changed the embedded database from versions [3.71.0 forward](https://help.sonatype.com/en/sonatype-nexus-repository-3-71-0-release-notes.html). The older versions used orientDB, which require a small change in the URL when searching for component data.

This patch adds a configuration option so that Cachito can handle both versions Nexus.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- (waived for nexus.py) New code has type annotations
- n/a OpenAPI schema is updated (if applicable)
- n/a DB schema change has corresponding DB migration (if applicable)
- n/a README updated (if worker configuration changed, or if applicable)
- n/a Draft release notes are updated before merging
